### PR TITLE
Removed tprintf convenience function, which was crashing due to some

### DIFF
--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -101,17 +101,17 @@ void set_hunting(struct char_data *ch, struct char_data *victim);
 
 
 
-/*****************************************/ 
+/*****************************************/
 
 
-struct no_load_type 
+struct no_load_type
 {
   int item_num;
   int min_level;
 };
 typedef struct no_load_type load_limits;
 
-static load_limits ObjLimits[] = 
+static load_limits ObjLimits[] =
 {
         {81,   LEVEL_GRGOD},    		/* Tracers ring */
         {82,   LEVEL_GRGOD},			/* Sword of doom */
@@ -125,7 +125,7 @@ load_limits *MobLimits = NULL;
 
 int num_moblim = sizeof (MobLimits) / sizeof (load_limits);
 
-/*****************************************/ 
+/*****************************************/
 
 ACMD(do_echo)
 {
@@ -140,7 +140,7 @@ ACMD(do_echo)
       {
         stc("You try to express yourself but cannot!\r\n", ch);
         return;
-      }  
+      }
       sprintf(buf, "$n %s", argument);
     }
     else
@@ -697,7 +697,7 @@ mob_race_name(int mob_race)
 }
 
 
-void 
+void
 do_stat_character(struct char_data * ch, struct char_data * k)
 {
   int clan_num, i, i2, found = 0;
@@ -715,7 +715,7 @@ do_stat_character(struct char_data * ch, struct char_data * k)
 
   sprintf(buf2, " %s '%s'  IDNum: [%5ld], In room [%5d]\r\n",
 	  (!IS_NPC(k) ? "PC" : (!IS_MOB(k) ? "NPC" : "MOB")),
-	  GET_NAME(k), GET_IDNUM(k), 
+	  GET_NAME(k), GET_IDNUM(k),
 	  k->in_room>-1 ? world[k->in_room].number : -1);
   send_to_char(strcat(buf, buf2), ch);
   if (IS_MOB(k)) {
@@ -725,7 +725,7 @@ do_stat_character(struct char_data * ch, struct char_data * k)
   }
   if (!IS_MOB(k))
   {
-    sprintf(buf, "Title: %s\r\n", 
+    sprintf(buf, "Title: %s\r\n",
 	   (k->player.title ? k->player.title : "<None>"));
     send_to_char(buf, ch);
   }
@@ -753,14 +753,14 @@ do_stat_character(struct char_data * ch, struct char_data * k)
     {
       strcpy(buf1, (char *) asctime(localtime(&(k->player.time.birth))));
       strcpy(buf2, (char *) asctime(localtime(&(k->player.time.logon))));
-      buf1[24] = buf2[24] = '\0'; 
+      buf1[24] = buf2[24] = '\0';
 
       sprintf(buf, "Created: [%s], Last Logon: [%s]\r\n", buf1, buf2) ;
 
       struct time_info_data pt = playing_time(k);
       sprintf(buf, "%sPlayed [%dd %dh], Age [%d]\r\n", buf,
 	      pt.day,
-	      pt.hours, 
+	      pt.hours,
 	      age(k).year);
       send_to_char(buf, ch);
 
@@ -836,7 +836,7 @@ do_stat_character(struct char_data * ch, struct char_data * k)
   }
 
   sprintf(buf, "Coins: [%9ld], Bank: [%9ld] (Total: %ld)\r\n",
-	  (long)GET_GOLD(k), (long)GET_BANK_GOLD(k), 
+	  (long)GET_GOLD(k), (long)GET_BANK_GOLD(k),
 	  (long)(GET_GOLD(k) + GET_BANK_GOLD(k)) );
   send_to_char(buf, ch);
 
@@ -938,13 +938,13 @@ do_stat_character(struct char_data * ch, struct char_data * k)
   }
 
   if (!IS_NPC(k))
-    if (GET_CLAN(k) && GET_CLAN_RANK(k) != 0) 
+    if (GET_CLAN(k) && GET_CLAN_RANK(k) != 0)
     {
       clan_num = find_clan_by_id(GET_CLAN(k));
       sprintf(buf, "Clan : %s\r\n", clan[clan_num].name);
       send_to_char(buf, ch);
-    } 
-  
+    }
+
   sprintf(buf, "Master is: %s, Followers are:",
 	  ((k->master) ? GET_NAME(k->master) : "<none>"));
 
@@ -1222,12 +1222,12 @@ ACMD(do_return)
 
 static void
 random_load_msg(struct char_data *ch)
-{ 
+{
 /* This has NOTHING to do with random load mobs         */
 /* This message merely shows when a god loads something */
     switch (number(0,2))
     {
-        case 0: 
+        case 0:
     	  act("Suddenly the walls run red with blood and a neon '666' sign "
 	      "flashes.", TRUE, ch, 0, 0, TO_ROOM);
     	  act("Suddenly the walls run red with blood and a neon '666' sign "
@@ -1302,7 +1302,7 @@ ACMD(do_load)
       }
 
       for (i = 0; i < num_moblim; i++) {
-         if ( (number == MobLimits[i].item_num) && 
+         if ( (number == MobLimits[i].item_num) &&
 	      (GET_LEVEL(ch) < MobLimits[i].min_level) ) {
  	    send_to_char("You're not godly enough to load that!\n\r", ch);
 	    return;
@@ -1316,7 +1316,7 @@ ACMD(do_load)
       mudlog(buf, BRF, GET_LEVEL(ch)+1, TRUE);
 
       act("$n makes a strange magickal gesture.", TRUE, ch, 0, 0, TO_ROOM);
-      random_load_msg(ch); 
+      random_load_msg(ch);
       act("$n has created $N!", FALSE, ch, 0, mob, TO_ROOM);
       act("You create $N.", FALSE, ch, 0, mob, TO_CHAR);
    } else if (is_abbrev(buf, "obj")) {
@@ -1325,7 +1325,7 @@ ACMD(do_load)
 	 return;
       }
       for (i = 0; i < num_objlim; i++)
-         if ( (number == ObjLimits[i].item_num) && 
+         if ( (number == ObjLimits[i].item_num) &&
               (GET_LEVEL(ch) < ObjLimits[i].min_level) ) {
             send_to_char("You're not godly enough to load that!\n\r", ch);
             return;
@@ -1335,30 +1335,30 @@ ACMD(do_load)
       cantload=FALSE;
       switch(GET_LEVEL(ch)){
 	case 31:			/*IMMORT*/
-		if(obj->obj_flags.cost>4000) cantload=TRUE; 
+		if(obj->obj_flags.cost>4000) cantload=TRUE;
 		break;
 	case 32:
-		if(obj->obj_flags.cost>5000) cantload=TRUE; 
+		if(obj->obj_flags.cost>5000) cantload=TRUE;
 		break;
 	case 33:
-		if(obj->obj_flags.cost>5500) cantload=TRUE; 
+		if(obj->obj_flags.cost>5500) cantload=TRUE;
 		break;
 	case 34:
-		if(obj->obj_flags.cost>6000) cantload=TRUE; 
+		if(obj->obj_flags.cost>6000) cantload=TRUE;
 		break;
 	case 35:
-		if(obj->obj_flags.cost>7000) cantload=TRUE; 
+		if(obj->obj_flags.cost>7000) cantload=TRUE;
 		break;
 	case 36:
-		if(obj->obj_flags.cost>7500) cantload=TRUE; 
+		if(obj->obj_flags.cost>7500) cantload=TRUE;
 		break;
 	case 37:
-		if(obj->obj_flags.cost>8000) cantload=TRUE; 
+		if(obj->obj_flags.cost>8000) cantload=TRUE;
 		break;
 	default:			/*GR_GOD+ can load anything*/
 		break;
       }
-	
+
       if (cantload){
 	 send_to_char("That is beyond your godly powers...\n\r",ch);
 	 extract_obj(obj);
@@ -1371,7 +1371,7 @@ ACMD(do_load)
       mudlog(buf, BRF, GET_LEVEL(ch)+1, TRUE);
 
       act("$n makes a strange magickal gesture.", TRUE, ch, 0, 0, TO_ROOM);
-      random_load_msg(ch); 
+      random_load_msg(ch);
       act("$n has created $p!", FALSE, ch, obj, 0, TO_ROOM);
       act("You create $p.", FALSE, ch, obj, 0, TO_CHAR);
    } else
@@ -1445,11 +1445,11 @@ ACMD(do_purge)
 	}
       }
       extract_char(vict);
-    } 
+    }
     else if((obj = get_obj_in_list_vis(ch, buf, world[ch->in_room].contents))) {
       act("$n destroys $p.", FALSE, ch, obj, 0, TO_ROOM);
       extract_obj(obj);
-    } 
+    }
     else {
       send_to_char("Nothing here by that name.\r\n", ch);
       return;
@@ -1465,9 +1465,9 @@ ACMD(do_purge)
       if (IS_NPC(vict))
 	extract_char(vict);
     }
-    
+
     extract_pending_chars();
-    
+
     for (obj = world[ch->in_room].contents; obj; obj = next_o) {
       next_o = obj->next_content;
       extract_obj(obj);
@@ -1537,7 +1537,7 @@ ACMD(do_advance)
     con = victim->real_abils.con;
     cha = victim->real_abils.cha;
     wis = victim->real_abils.wis;
-    
+
     send_to_char("You are momentarily enveloped by darkness!\r\n"
 		 "You can feel all your power and knowledge being\r\n"
                  "drained away from you!\r\n", victim);
@@ -1565,10 +1565,10 @@ ACMD(do_advance)
 	"Suddenly a silent explosion of light\r\n"
 	"snaps you back to reality.\r\n\r\n"
 	"You feel slightly different.", FALSE, ch, 0, victim, TO_VICT);
-   
+
     for (i = GET_LEVEL(victim); i < newlevel; i++)
      gain_exp_regardless(victim,
-   			(exp_needed_for_level(victim) - GET_EXP(victim))); 
+   			(exp_needed_for_level(victim) - GET_EXP(victim)));
 
   }
 
@@ -1623,13 +1623,13 @@ void perform_immort_vis(struct char_data *ch)
 {
   void appear(struct char_data *ch);
 
-  if (GET_INVIS_LEV(ch) == 0 && 
-      (!IS_AFFECTED(ch, AFF_HIDE) || 
+  if (GET_INVIS_LEV(ch) == 0 &&
+      (!IS_AFFECTED(ch, AFF_HIDE) ||
        !IS_AFFECTED(ch, AFF_INVISIBLE))) {
     send_to_char("You are already fully visible.\r\n", ch);
     return;
   }
-   
+
   GET_INVIS_LEV(ch) = 0;
   appear(ch);
   send_to_char("You are now fully visible.\r\n", ch);
@@ -1658,7 +1658,7 @@ void perform_immort_invis(struct char_data *ch, int level)
   sprintf(buf, "Your invisibility level is %d.\r\n", level);
   send_to_char(buf, ch);
 }
-  
+
 
 ACMD(do_invis)
 {
@@ -1874,7 +1874,7 @@ ACMD(do_force)
       send_to_char(OK, ch);
       if (GET_LEVEL(ch)<LVL_IMPL)
         act(buf1, TRUE, ch, NULL, vict, TO_VICT);
-      sprintf(buf, "(GC) %s forced %s to %s", GET_NAME(ch), GET_NAME(vict), 
+      sprintf(buf, "(GC) %s forced %s to %s", GET_NAME(ch), GET_NAME(vict),
                to_force);
       mudlog(buf, NRM, MAX(GET_LEVEL(ch)+1, GET_INVIS_LEV(ch)), TRUE);
       command_interpreter(vict, to_force);
@@ -2006,16 +2006,16 @@ ACMD(do_wiznet)
     sprintf(buf2, "Someone: %s%s\r\n", emote ? "<--- " : "", argument);
   }
 
-  for (d = descriptor_list; d; d = d->next) 
+  for (d = descriptor_list; d; d = d->next)
   {
-    if ((!d->connected) && 
+    if ((!d->connected) &&
 	/*  they are immortal, or chosen and the wiz is at default level */
-	(GET_LEVEL(d->character) >= level || 
+	(GET_LEVEL(d->character) >= level ||
 	 (PLR_FLAGGED(d->character, PLR_CHOSEN)&& !noChosen)) &&
 	(!PRF_FLAGGED(d->character, PRF_NOWIZ)) &&
 	(!PLR_FLAGGED(d->character, PLR_MAILING) ||
          !PLR_FLAGGED(d->character, PLR_WRITING))
-	&& (d != ch->desc || !(PRF_FLAGGED(d->character, PRF_NOREPEAT)))) 
+	&& (d != ch->desc || !(PRF_FLAGGED(d->character, PRF_NOREPEAT))))
     {
       send_to_char(CCCYN(d->character, C_NRM), d->character);
       if (CAN_SEE(d->character, ch))
@@ -2316,7 +2316,7 @@ ACMD(do_show)
       else
 	for (i = 0; i <= top_of_zone_table; i++)
 	  print_zone_to_buf(buf, i);
-      page_string(ch->desc, buf, 1); 
+      page_string(ch->desc, buf, 1);
       break;
     case 2:			/* player */
       if (!*value)
@@ -2370,7 +2370,7 @@ ACMD(do_show)
 	    }
 	}
       for (obj = object_list; obj; obj = obj->next)
-	k++;
+	      k++;
       sprintf(buf, "Current stats:\r\n");
       sprintf(buf, "%s  %5d players in game  %5d connected\r\n", buf, i, con);
       sprintf(buf, "%s  %5d registered\r\n", buf, top_of_p_table + 1);
@@ -2416,7 +2416,7 @@ ACMD(do_show)
     case 9:
       hcontrol_list_houses(ch);
       break;
-    case 10: 
+    case 10:
       {
  	int i = 0;
 	for (i=0; i<NUM_TATTOOS; i++)
@@ -2436,7 +2436,7 @@ ACMD(do_show)
            char mybuf[256];
            sprintf(mybuf, "%d %s\r\n", GET_MOB_VNUM(vict), GET_NAME(vict));
            send_to_char(mybuf, ch);
-          } 		
+          }
         }
      }
     break;
@@ -2449,13 +2449,13 @@ ACMD(do_show)
      {
       char *reagents = get_reagent_names(find_skill_num(spells[sortpos]));
       if(reagents)
-	{
-	 char *mystr = tprintf("%s:  %s\r\n",spells[sortpos], reagents);
-	 stc(mystr, ch);
-	 FREE(mystr);
-	 FREE(reagents);
-	}
-     }
+	    {
+        char mystr[MAX_STRING_LENGTH];
+        sprintf(mystr, "%s:  %s\r\n", spells[sortpos], reagents);
+	      stc(mystr, ch);
+	      FREE(reagents);
+	   }
+    }
     }
     break;
     case 13:
@@ -2470,7 +2470,7 @@ ACMD(do_show)
 	  if (i > top_of_zone_table)
 	     sprintf(buf, "That is not a valid zone.\r\n");
 	  else {
-	     sprintf(buf, "Connections in zone %d.\r\n", 
+	     sprintf(buf, "Connections in zone %d.\r\n",
                      zone_table[i].number);
 	     strcat(buf,  "========================\r\n");
 	     for(j = 0; j <= top_of_world; j++)
@@ -2479,15 +2479,15 @@ ACMD(do_show)
 	              if (world[j].dir_option[k] &&
 		          world[world[j].dir_option[k]->to_room].zone != i)
 		         sprintf(buf, "%s%5d leads %s to %-5d -- %s\r\n", buf,
-			   world[j].number, dirs[k], 
+			   world[j].number, dirs[k],
 			   world[world[j].dir_option[k]->to_room].number,
 	                   zone_table[world[world[j].dir_option[k]->to_room].zone].name);
 	 }
        }
-       send_to_char(buf, ch);                          
+       send_to_char(buf, ch);
      }
     }
-    break;      
+    break;
     case 14: /* show neutral rooms*/
     {
       strcpy(buf, "Neutral Rooms\r\n-------------\r\n");
@@ -2588,8 +2588,8 @@ ACMD(do_set)
     { "passwd",		LVL_IMPL-1, 	PC, 	MISC },    /* 45 */
     { "nodelete", 	LVL_GOD, 	PC, 	BINARY },
     { "cha",		LVL_GRGOD, 	BOTH, 	NUMBER },
-    { "olc",		LVL_SET_BUILD, 	PC, 	NUMBER }, 
-    { "race",		LVL_GOD, 	PC, 	MISC }, 
+    { "olc",		LVL_SET_BUILD, 	PC, 	NUMBER },
+    { "race",		LVL_GOD, 	PC, 	MISC },
     { "kills",		LVL_GRGOD, 	BOTH, 	NUMBER },  /* 50 */
     { "pks",		LVL_GRGOD, 	BOTH, 	NUMBER },
     { "deaths",		LVL_GRGOD, 	BOTH, 	NUMBER },
@@ -2655,7 +2655,7 @@ ACMD(do_set)
          if ( (str_cmp("Orodreth", GET_NAME(ch)) != 0) &&
                (str_cmp("Serapis", GET_NAME(ch)) != 0) )
           {
-	     if (GET_LEVEL(cbuf) >= GET_LEVEL(ch)) 
+	     if (GET_LEVEL(cbuf) >= GET_LEVEL(ch))
 	     {
 	        free_char(cbuf);
 	        send_to_char("Sorry, you can't do that.\r\n", ch);
@@ -2671,14 +2671,14 @@ ACMD(do_set)
 	  return;
 	}
     }
-   if (GET_LEVEL(ch) != LVL_IMPL)  
+   if (GET_LEVEL(ch) != LVL_IMPL)
     {
-      if (!IS_NPC(vict) && GET_LEVEL(ch) <= GET_LEVEL(vict) && vict != ch) 
+      if (!IS_NPC(vict) && GET_LEVEL(ch) <= GET_LEVEL(vict) && vict != ch)
 	{
 	  send_to_char("Maybe that's not such a great idea...\r\n", ch);
 	  return;
 	}
-    } 
+    }
   for (l = 0; *(fields[l].cmd) != '\n'; l++)
     if (!strncmp(field, fields[l].cmd, strlen(field)))
       break;
@@ -2887,9 +2887,9 @@ ACMD(do_set)
       break;
     case 33:
       if ((q = find_name(GET_NAME(vict))) != -1)
-         strcpy((player_table + q)->name, val_arg); 
+         strcpy((player_table + q)->name, val_arg);
        strcpy(old_name, GET_NAME(vict));
-       strcpy(GET_NAME(vict), val_arg); 
+       strcpy(GET_NAME(vict), val_arg);
        Crash_delete_file(old_name);
        Alias_delete_file(old_name);
        save_char(vict, NOWHERE);
@@ -2924,7 +2924,7 @@ ACMD(do_set)
         {
           GET_CLAN(vict) = 0;
           GET_CLAN_RANK(vict) = 0;
-          clan[clan_num].members--;  
+          clan[clan_num].members--;
           clan[clan_num].power-=GET_LEVEL(vict);
         }
         Crash_delete_file(GET_NAME(vict));
@@ -3173,21 +3173,21 @@ ACMD(do_dns)
     for(i = 0; i < DNS_HASH_NUM; i++) {
       if(dns_cache[i]) {
          for(tdns = dns_cache[i]; tdns; tdns = tdns->next) {
-           if (tdns->ip[0] < 0) 
+           if (tdns->ip[0] < 0)
               break;
-           if (tdns->ip[0] < 10) 
+           if (tdns->ip[0] < 10)
               sprintf(buf, "%s00%d.", buf, tdns->ip[0]);
            else if (tdns->ip[0] < 100)
               sprintf(buf, "%s0%d.", buf, tdns->ip[0]);
            else
               sprintf(buf, "%s%d.", buf, tdns->ip[0]);
-           if (tdns->ip[1] < 10) 
+           if (tdns->ip[1] < 10)
               sprintf(buf, "%s00%d.", buf, tdns->ip[1]);
            else if (tdns->ip[1] < 100)
               sprintf(buf, "%s0%d.", buf, tdns->ip[1]);
            else
               sprintf(buf, "%s%d.", buf, tdns->ip[1]);
-           if (tdns->ip[2] < 10) 
+           if (tdns->ip[2] < 10)
               sprintf(buf, "%s00%d.", buf, tdns->ip[2]);
            else if (tdns->ip[2] < 100)
               sprintf(buf, "%s0%d.", buf, tdns->ip[2]);
@@ -3195,7 +3195,7 @@ ACMD(do_dns)
               sprintf(buf, "%s%d.", buf, tdns->ip[2]);
            if (tdns->ip[3] < 0)
               sprintf(buf, "%s   ", buf);
-           else if (tdns->ip[3] < 10) 
+           else if (tdns->ip[3] < 10)
               sprintf(buf, "%s00%d", buf, tdns->ip[3]);
            else if (tdns->ip[3] < 100)
               sprintf(buf, "%s0%d", buf, tdns->ip[3]);
@@ -3214,7 +3214,7 @@ ACMD(do_dns)
 ACMD(do_dark)
 {
 	struct char_data *rch;
-    
+
 	if (IS_NPC(ch))
        		return;
    	for (rch = world[ch->in_room].people;rch;rch = rch->next_in_room)
@@ -3223,7 +3223,7 @@ ACMD(do_dark)
          	{
            		stop_fighting(rch);
            		if (IS_MOB(rch) && MEMORY(rch))
-				MEMORY(rch) = NULL;		   
+				MEMORY(rch) = NULL;
         		send_to_char("The peace of the ancients fills your"
 				     " soul.\n\r", rch);
          	}
@@ -3236,10 +3236,10 @@ ACMD(do_dark)
 }
 
 ACMD(do_home)
-{ 
+{
  int location;
  char buf[MAX_STRING_LENGTH], tmp[10];
- 
+
  if (IS_NPC(ch))
     return;
  one_argument(argument, tmp);
@@ -3273,15 +3273,15 @@ ACMD(do_home)
   {
    SET_BIT_AR(PLR_FLAGS(ch), PLR_LOADROOM);
    location = atoi(tmp);
-   
+
    if (find_target_room(ch, argument) < 0)
         {
         send_to_char("That room does not exist.\n\r",ch);
         return;
         }
 
-   if ( real_room(location) > 0 && 
-	IS_SET_AR(world[real_room(location)].room_flags, ROOM_GODROOM) && 
+   if ( real_room(location) > 0 &&
+	IS_SET_AR(world[real_room(location)].room_flags, ROOM_GODROOM) &&
        	GET_LEVEL(ch) < LEVEL_GRGOD )
    {
         send_to_char("You're not godly enough for that room.\r\n",ch);
@@ -3299,18 +3299,18 @@ ACMD(do_home)
   return;
   }
  }
-} 
+}
 
 ACMD (do_olist)
 {
   extern struct index_data *obj_index;
   extern struct obj_data *obj_proto;
- 
+
   int j, nr, start, end, found = 0;
   char f;
- 
+
   one_argument(argument, arg);
- 
+
   j = atoi(arg);
   start = (j * 100);
   end = (start + 99);
@@ -3324,12 +3324,12 @@ ACMD (do_olist)
 		obj_index[nr].virtual,
 		obj_proto[nr].short_description);
       }
-  
+
   if (f == 'N')
     sprintf(buf, "Sorry, there are no objs in that zone.\r\n");
   else
     sprintf(buf, "%s %d Objects found in Zone %d\r\n", buf, found, j);
- 
+
   page_string(ch->desc, buf, 1);
 }
 
@@ -3341,10 +3341,10 @@ ACMD(do_rlist)
   bool overflow = FALSE;
 
   one_argument(argument, arg);
- 
+
   j = atoi(arg);
   buf[0] = '\0';
- 
+
   for (ii = 0; ii <= top_of_world; ii++)
     if (zone_table[world[ii].zone].number == j)
       {
@@ -3364,11 +3364,11 @@ ACMD(do_rlist)
     send_to_char("The desired zone does not exist.\r\n", ch);
     return;
   }
-  
+
   if (overflow) {
 	send_to_char("Truncating room list due to size.\r\n", ch);
   }
-  
+
   page_string(ch->desc, buf, 1);
 }
 
@@ -3377,20 +3377,20 @@ ACMD (do_mlist)
 {
   extern struct index_data *mob_index;   /* index table for mobile file   */
   extern struct char_data *mob_proto;    /* prototypes for mobs           */
- 
- 
+
+
   int j, nr, start, end, found = 0;
   char f;
- 
+
   one_argument(argument, arg);
- 
+
   j = atoi(arg);
   start = (j * 100);
   end = (start + 99);
   f = 'N';
   buf[0] = '\0';
- 
-  for (nr = 0; nr <= top_of_mobt; nr++) 
+
+  for (nr = 0; nr <= top_of_mobt; nr++)
     if ((mob_index[nr].virtual >= start) && (mob_index[nr].virtual <= end))
       {
         f = 'Y';
@@ -3402,7 +3402,7 @@ ACMD (do_mlist)
     sprintf(buf, "Sorry, there are no mobs in that zone.\r\n");
   else
     sprintf(buf, "%s %d Mobiles found in Zone %d\r\n", buf, found, j);
- 
+
   page_string(ch->desc, buf, 1);
 }
 
@@ -3454,7 +3454,7 @@ ACMD(do_sethunt)
   if(!*buf)
 	send_to_char("Who do you wish to hunt?\n\r", ch);
   else if (!(victim = get_char_vis(ch, buf)))
-	send_to_char("No-one by that name around.\n\r", ch); 
+	send_to_char("No-one by that name around.\n\r", ch);
   else if (!(hunter = get_char_vis(ch, buf2)))
 	send_to_char("Who shall be the hunter?\n\r",ch);
   else if (hunter==victim)
@@ -3463,7 +3463,7 @@ ACMD(do_sethunt)
 	send_to_char("PCs can't be made to hunt.\n\r",ch);
   else {
 	if(GET_LEVEL(ch)<GET_LEVEL(victim)) {
-		send_to_char("Cant hunt higher than your level.\n\r",ch); 
+		send_to_char("Cant hunt higher than your level.\n\r",ch);
 		return;
 	}
  	if(!MOB_FLAGGED(hunter,MOB_HUNTER))
@@ -3484,7 +3484,7 @@ random_room_in_zone(int vnum)
     if (i >= 0 && i <= top_of_zone_table) {
      do {
           to_room = number(0, top_of_world);
-     }  
+     }
      while( (IS_SET_AR(world[to_room].room_flags,ROOM_PRIVATE))
          ||(IS_SET_AR(world[to_room].room_flags,ROOM_GODROOM))
          ||(IS_SET_AR(world[to_room].room_flags,ROOM_DEATH))
@@ -3493,7 +3493,7 @@ random_room_in_zone(int vnum)
     }
     return( to_room );
 }
-                  
+
 /*-------------------------------------------------------------------------*\
   tick -- make the mud tick now!
 \*-------------------------------------------------------------------------*/
@@ -3509,13 +3509,13 @@ ACMD(do_tick)
   point_update();
   hunt_items();
   fflush(player_fl);
-}  
+}
 
 
 
 ACMD(do_newbie)
 {
-  
+
   struct char_data *vict = NULL;
   struct obj_data *obj   = NULL;
   int give_obj[] = {8019, 8062, 8063, 8023, -1};/* tunic, bread, skin, club */
@@ -3547,16 +3547,16 @@ ACMD(do_zlist)
         FILE* f = NULL;
 	int j = 0;
         char cp[256];
-  
+
 	one_argument(argument, arg);
- 
+
   	j = atoi(arg);
 
 	if (!*arg)
 	  j = zone_table[ world[ch->in_room].zone ].number;
 
 	sprintf(cp, "world/zon/%d.zon", j);
-	
+
         f = fopen(cp,"r");
 	if (f)
 	{
@@ -3591,7 +3591,7 @@ ACMD(do_idlist) {
 
   /* loop here */
   for (nr = 0; nr <= top_of_objt; nr++) {
-    fprintf(fp, "Object: '%s', Item type: ", 
+    fprintf(fp, "Object: '%s', Item type: ",
 	    obj_proto[nr].short_description);
     type = obj_proto[nr].obj_flags.type_flag;
     if(type == ITEM_STAFF || type == ITEM_WAND) {
@@ -3605,10 +3605,10 @@ ACMD(do_idlist) {
 		   AF_ARRAY_MAX, buf);
     fprintf(fp, "%s\n", buf);
     fprintf(fp, "Item is: ");
-    sprintbitarray(obj_proto[nr].obj_flags.extra_flags, extra_bits, 
+    sprintbitarray(obj_proto[nr].obj_flags.extra_flags, extra_bits,
 		   EF_ARRAY_MAX, buf);
     fprintf(fp, "%s\n", buf);
-    fprintf(fp, "Encumbrance: %d, Value: %d\n", 
+    fprintf(fp, "Encumbrance: %d, Value: %d\n",
 	    obj_proto[nr].obj_flags.weight, obj_proto[nr].obj_flags.cost);
     switch(type) {
     case ITEM_SCROLL:
@@ -3672,13 +3672,13 @@ ACMD(do_idlist) {
 
 #define ZCMD zone_table[zone].cmd[cmd_no]
 
-/* 
+/*
   type  = 'O' or 'M'
   which = real number of mob/object
   name = common name of mob/object
 */
 
-static void check_load(char type, int which, struct char_data *ch, 
+static void check_load(char type, int which, struct char_data *ch,
 		       char *name)
 {
   int zone, lastroom_v = 0, lastroom_r = 0, lastmob_r = 0;
@@ -3690,17 +3690,17 @@ static void check_load(char type, int which, struct char_data *ch,
   char *objname = buf2;
   struct char_data *mob = NULL;
   struct obj_data *obj = NULL;
-  
+
   sprintf(buf, "Checking load info for %s...\r\n", name);
 
   for (zone = 0; zone <= top_of_zone_table; zone++)
-    for (cmd_no = 0; ZCMD.command != 'S'; cmd_no++) 
+    for (cmd_no = 0; ZCMD.command != 'S'; cmd_no++)
       if (type == 'm' || type == 'M')
         switch (ZCMD.command) {
 	case 'M':                   /* read a mobile */
 	  if (ZCMD.arg1 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
 		    "         %d Max\r\n",
 		    world[ZCMD.arg3].number, world[ZCMD.arg3].name, ZCMD.arg2);
@@ -3711,7 +3711,7 @@ static void check_load(char type, int which, struct char_data *ch,
 	  lastroom_r = ZCMD.arg1;
 	  if (!ZCMD.arg2 && ZCMD.arg3 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
 		    "         Removed from room\r\n",
 		    lastroom_v, world[lastroom_r].name);
@@ -3734,7 +3734,7 @@ static void check_load(char type, int which, struct char_data *ch,
 	default:
 	  break;
 	}
-  
+
 	switch (ZCMD.command) {
 	case 'M':
 	case 'O':
@@ -3755,7 +3755,7 @@ static void check_load(char type, int which, struct char_data *ch,
 	case 'O':                   /* read an object */
 	  if (ZCMD.arg1 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
 		    "         Loaded to room\r\n"
 		    "         %.2f%% Load, %d Max\r\n",
@@ -3765,7 +3765,7 @@ static void check_load(char type, int which, struct char_data *ch,
 	case 'P':                   /* object to object */
 	  if (ZCMD.arg1 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
 		    "         Put in %s [%d]\r\n"
 		    "         %.2f%% Load, %d Max\r\n",
@@ -3775,11 +3775,11 @@ static void check_load(char type, int which, struct char_data *ch,
 	  break;
 	case 'E':                   /* equip an object */
 	  if (ZCMD.arg1 == which) {
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
                     "         Equipped to %s [%d]\r\n"
 		    "         %.2f%% Load, %d Max\r\n",
-		    lastroom_v, world[lastroom_r].name, mobname, 
+		    lastroom_v, world[lastroom_r].name, mobname,
 		    mob_index[lastmob_r].virtual, perc_load, ZCMD.arg2);
 	    found = true;
 	  }
@@ -3787,11 +3787,11 @@ static void check_load(char type, int which, struct char_data *ch,
 	case 'G':                  /* give an object */
 	  if (ZCMD.arg1 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
 		    "         Given to %s [%d]\r\n"
 		    "         %.2f%% Load, %d Max\r\n",
-		    lastroom_v, world[lastroom_r].name, mobname, 
+		    lastroom_v, world[lastroom_r].name, mobname,
 		    mob_index[lastmob_r].virtual, perc_load, ZCMD.arg2);
 	  }
 	  break;
@@ -3800,16 +3800,16 @@ static void check_load(char type, int which, struct char_data *ch,
 	  lastroom_r = ZCMD.arg1;
 	  if (ZCMD.arg2 && ZCMD.arg3 == which) {
 	    found = true;
-	    sprintf(buf+strlen(buf), 
+	    sprintf(buf+strlen(buf),
 		      " [%5d] %s\r\n"
-		    "         Removed from room\r\n", 
+		    "         Removed from room\r\n",
 		    lastroom_v, world[lastroom_r].name);
 	  }
 	  break;
 	}
       } else
 	return;
-  
+
   send_to_char(buf, ch);
 
   if (!found)
@@ -3817,7 +3817,7 @@ static void check_load(char type, int which, struct char_data *ch,
 }
 
 ACMD(do_checkload)
-{  
+{
   long which;
   struct char_data *mob;
   struct obj_data *obj;
@@ -3828,7 +3828,7 @@ ACMD(do_checkload)
   if ((!*buf2) || (!*buf3) || (!isdigit(*buf3))) {
     send_to_char(usage, ch);
     return;
-  }   
+  }
 
   switch (*buf2) {
   case 'M':

--- a/src/comm.c
+++ b/src/comm.c
@@ -379,7 +379,6 @@ int get_max_players(void)
 #endif
   {
     struct rlimit limit;
-
     /* find the limit of file descs */
     method = "rlimit";
     if (getrlimit(RLIMIT_NOFILE, &limit) < 0) {
@@ -387,6 +386,9 @@ int get_max_players(void)
       exit(1);
     }
     /* set the current to the maximum */
+#ifdef OPEN_MAX 
+limit.rlim_max = limit.rlim_max > OPEN_MAX? OPEN_MAX : limit.rlim_max; 
+#endif 
     limit.rlim_cur = limit.rlim_max;
     if (setrlimit(RLIMIT_NOFILE, &limit) < 0) {
       perror("SYSERR: calling setrlimit");

--- a/src/handler.c
+++ b/src/handler.c
@@ -48,7 +48,7 @@ extern struct obj_data *object_list;
 extern struct char_data *character_list;
 extern struct index_data *mob_index;
 extern struct index_data *obj_index;
-extern struct obj_data *obj_proto;     /* prototypes for objs           */  
+extern struct obj_data *obj_proto;     /* prototypes for objs           */
 extern struct descriptor_data *descriptor_list;
 extern char *MENU;
 
@@ -89,16 +89,16 @@ int isname(char *str, char *namelist)
   for (;;) {
     for (curstr = str;; curstr++, curname++) {
       if (!*curstr && !isalpha(*curname))
-	return (1);
+  return (1);
 
       if (!*curname)
-	return (0);
+  return (0);
 
       if (!*curstr || *curname == ' ')
-	break;
+  break;
 
       if (LOWER(*curstr) != LOWER(*curname))
-	break;
+  break;
     }
 
     /* skip to next name */
@@ -106,13 +106,13 @@ int isname(char *str, char *namelist)
     for (; isalpha(*curname); curname++);
     if (!*curname)
       return (0);
-    curname++;			/* first char of new name */
+    curname++;      /* first char of new name */
   }
 }
 
 #define WHITESPACE " \t"
 /* unused, but works */
-int 
+int
 isname_with_abbrevs(char *str, char *namelist)
 {
   register char *newlist, *curtok;
@@ -120,12 +120,12 @@ isname_with_abbrevs(char *str, char *namelist)
   {
    newlist = strdup(namelist);
 
-   for(curtok = strtok(newlist, WHITESPACE); 
-       curtok; 
+   for(curtok = strtok(newlist, WHITESPACE);
+       curtok;
        curtok = strtok(NULL, WHITESPACE))
          if(curtok && is_abbrev(str, curtok))
           {
-            FREE(newlist); 
+            FREE(newlist);
             return 1;
           }
    FREE(newlist);
@@ -177,7 +177,7 @@ void aff_apply_modify(struct char_data *ch, byte loc, sbyte mod, char *msg)
      case APPLY_MOVE_REGEN:
                         break;
      case APPLY_HIT_REGEN:
-			break;
+      break;
      case APPLY_EXP:    break;
      case APPLY_AC:     GET_AC(ch) += mod;
                         break;
@@ -202,7 +202,7 @@ void aff_apply_modify(struct char_data *ch, byte loc, sbyte mod, char *msg)
      case APPLY_SAVING_SPELL:
                         GET_SAVE(ch, SAVING_SPELL) += mod;
                         break;
-    case APPLY_RACE_HATE: 
+    case APPLY_RACE_HATE:
                         /* Turn off any race_hates (but 0(HUMAN) ) */
                         if (mod < 0) {
                           for (i = 0; i < 5; i++)
@@ -238,36 +238,36 @@ void aff_apply_modify(struct char_data *ch, byte loc, sbyte mod, char *msg)
                          }
                          break;
      case APPLY_SPELL:
-	if(IS_NPC(ch))
-		break;
-	else
-	{
-   			struct master_affected_type *aff;
-			if (mod > 0)
-			{
-			  int found = 0; 
-  			  if (ch->affected)
-    			    for (aff = ch->affected; aff; aff = aff->next)
-      				if (aff->bitvector)
-				  if (aff->bitvector == mod)
-				    found = 1;
-			  if (!found)
-			    SET_BIT_AR(AFF_FLAGS(ch), mod);
-			}
-			else
-			{
-			  int found = 0; 
-  			  if (ch->affected)
-    			    for (aff = ch->affected; aff; aff = aff->next)
-      				if (aff->bitvector)
-				  if (aff->bitvector == -mod)
-				    found = 1;
-			  if (!found)
-			    REMOVE_BIT_AR(AFF_FLAGS(ch), -mod);
-			}
-	} /*!IS_NPC*/
+  if(IS_NPC(ch))
+    break;
+  else
+  {
+         struct master_affected_type *aff;
+      if (mod > 0)
+      {
+        int found = 0;
+          if (ch->affected)
+              for (aff = ch->affected; aff; aff = aff->next)
+              if (aff->bitvector)
+          if (aff->bitvector == mod)
+            found = 1;
+        if (!found)
+          SET_BIT_AR(AFF_FLAGS(ch), mod);
+      }
+      else
+      {
+        int found = 0;
+          if (ch->affected)
+              for (aff = ch->affected; aff; aff = aff->next)
+              if (aff->bitvector)
+          if (aff->bitvector == -mod)
+            found = 1;
+        if (!found)
+          REMOVE_BIT_AR(AFF_FLAGS(ch), -mod);
+      }
+  } /*!IS_NPC*/
 
-			break;
+      break;
 
      default:           sprintf(buf, "SYSERR: Unknown apply (%d) adjust "
                                 "attempt (handler.c, %s).", loc, msg);
@@ -319,9 +319,9 @@ void affect_total(struct char_data * ch)
   for (i = 0; i < NUM_WEARS; i++) {
     if (GET_EQ(ch, i))
       for (j = 0; j < MAX_OBJ_AFFECT; j++)
-	affect_modify_ar(ch, GET_EQ(ch, i)->affected[j].location,
-		      GET_EQ(ch, i)->affected[j].modifier,
-		      GET_EQ(ch, i)->obj_flags.bitvector, FALSE);
+  affect_modify_ar(ch, GET_EQ(ch, i)->affected[j].location,
+          GET_EQ(ch, i)->affected[j].modifier,
+          GET_EQ(ch, i)->obj_flags.bitvector, FALSE);
   }
 
   for (af = ch->affected; af; af = af->next)
@@ -336,9 +336,9 @@ void affect_total(struct char_data * ch)
   for (i = 0; i < NUM_WEARS; i++) {
     if (GET_EQ(ch, i))
       for (j = 0; j < MAX_OBJ_AFFECT; j++)
-	affect_modify_ar(ch, GET_EQ(ch, i)->affected[j].location,
-		      GET_EQ(ch, i)->affected[j].modifier,
-		      GET_EQ(ch, i)->obj_flags.bitvector, TRUE);
+  affect_modify_ar(ch, GET_EQ(ch, i)->affected[j].location,
+          GET_EQ(ch, i)->affected[j].modifier,
+          GET_EQ(ch, i)->obj_flags.bitvector, TRUE);
   }
 
   for (af = ch->affected; af; af = af->next)
@@ -365,17 +365,17 @@ void affect_total(struct char_data * ch)
       GET_STR(ch) = 18;
     }
   }
- 
+
   if (GET_ALIGNMENT(ch)>1000)
-	GET_ALIGNMENT(ch) = 1000;
+  GET_ALIGNMENT(ch) = 1000;
   if (GET_ALIGNMENT(ch)<-1000)
-	GET_ALIGNMENT(ch) = -1000;
+  GET_ALIGNMENT(ch) = -1000;
 }
 
 
 /* Serapis Wed Jun 10 10:07:12 1998 */
 void master_affect_to_char(struct char_data *ch, struct affected_type *af,
-			   by_types_enum by_type, int obj_num)
+         by_types_enum by_type, int obj_num)
 {
   struct master_affected_type *affected_alloc;
 
@@ -411,7 +411,7 @@ void affect_to_char2(struct char_data *ch, struct master_affected_type *af)
   *affected_alloc = *af;
   affected_alloc->by_type = BY_SPELL;
   affected_alloc->obj_num = 0;
-  
+
   affected_alloc->next = ch->affected;
   ch->affected = affected_alloc;
 
@@ -471,7 +471,7 @@ bool affected_by_spell(struct char_data * ch, int type)
 
 
 void affect_join(struct char_data * ch, struct master_affected_type * af,
-		      bool add_dur, bool avg_dur, bool add_mod, bool avg_mod)
+          bool add_dur, bool avg_dur, bool add_mod, bool avg_mod)
 {
   struct master_affected_type *hjp;
   bool found = FALSE;
@@ -480,14 +480,14 @@ void affect_join(struct char_data * ch, struct master_affected_type * af,
 
     if ((hjp->type == af->type) && (hjp->location == af->location)) {
       if (add_dur)
-	af->duration += hjp->duration;
+  af->duration += hjp->duration;
       if (avg_dur)
-	af->duration >>= 1;
+  af->duration >>= 1;
 
       if (add_mod)
-	af->modifier += hjp->modifier;
+  af->modifier += hjp->modifier;
       if (avg_mod)
-	af->modifier >>= 1;
+  af->modifier >>= 1;
 
       affect_remove(ch, hjp);
       affect_to_char2(ch, af);
@@ -503,7 +503,7 @@ void affect_join(struct char_data * ch, struct master_affected_type * af,
 void char_from_room(struct char_data * ch)
 {
   struct char_data *temp, *i;
-  
+
   if (ch == NULL || ch->in_room == NOWHERE) {
     log("SYSERR: NULL or NOWHERE in handler.c, char_from_room");
     exit(1);
@@ -619,16 +619,16 @@ int apply_ac(struct char_data * ch, int eq_pos)
 
   case WEAR_BODY:
     factor = 3;
-    break;			/* 30% */
+    break;      /* 30% */
   case WEAR_HEAD:
     factor = 2;
-    break;			/* 20% */
+    break;      /* 20% */
   case WEAR_LEGS:
     factor = 2;
-    break;			/* 20% */
+    break;      /* 20% */
   default:
     factor = 1;
-    break;			/* all others 10% */
+    break;      /* all others 10% */
   }
 
   return (factor * GET_OBJ_VAL(GET_EQ(ch, eq_pos), 0));
@@ -639,40 +639,40 @@ int apply_ac(struct char_data * ch, int eq_pos)
 void
 check_for_bad_stats(struct char_data * ch)
 {
-	char bad_char = 0;
+  char bad_char = 0;
 
-	if (GET_STR(ch) == 0) bad_char = 's';
-	if (GET_INT(ch) == 0) bad_char = 'i';
-	if (GET_WIS(ch) == 0) bad_char = 'w';
-	if (GET_CHA(ch) == 0) bad_char = 'c';
-	if (GET_DEX(ch) == 0) bad_char = 'd';
-	
-	switch (bad_char)
-	{
-	case 0: break;
-	case 's': 
-		send_to_char("You are too weak to fight!\n\r", ch);
-		break;
-	case 'i':
-		send_to_char("You are too dumb to do much of anything!\n\r",ch);
-		break;
-	case 'w':
-		send_to_char("You are too dumb to do much of anything!\n\r",ch);
-		break;
-	case 'c':
-		send_to_char("The world hates you!\n\r", ch);
-		if (!HUNTING( get_char_num(real_mobile(PESTILENCE_VNUM))))
-		  set_hunting( get_char_num(real_mobile(PESTILENCE_VNUM)),ch);
-		break;
-	case 'd':
-		send_to_char("You trip over your own feet and hit your "
-				"head!\n\r",ch);
-		damage(ch, ch, 40, TYPE_SUFFERING);  
-		break;
-	default: 
-	    log("error (handler.c): illegal stat in check_for_bad_stats()");
-		break;
-	}
+  if (GET_STR(ch) == 0) bad_char = 's';
+  if (GET_INT(ch) == 0) bad_char = 'i';
+  if (GET_WIS(ch) == 0) bad_char = 'w';
+  if (GET_CHA(ch) == 0) bad_char = 'c';
+  if (GET_DEX(ch) == 0) bad_char = 'd';
+
+  switch (bad_char)
+  {
+  case 0: break;
+  case 's':
+    send_to_char("You are too weak to fight!\n\r", ch);
+    break;
+  case 'i':
+    send_to_char("You are too dumb to do much of anything!\n\r",ch);
+    break;
+  case 'w':
+    send_to_char("You are too dumb to do much of anything!\n\r",ch);
+    break;
+  case 'c':
+    send_to_char("The world hates you!\n\r", ch);
+    if (!HUNTING( get_char_num(real_mobile(PESTILENCE_VNUM))))
+      set_hunting( get_char_num(real_mobile(PESTILENCE_VNUM)),ch);
+    break;
+  case 'd':
+    send_to_char("You trip over your own feet and hit your "
+        "head!\n\r",ch);
+    damage(ch, ch, 40, TYPE_SUFFERING);
+    break;
+  default:
+      log("error (handler.c): illegal stat in check_for_bad_stats()");
+    break;
+  }
 }
 
 
@@ -680,12 +680,13 @@ void equip_char(struct char_data * ch, struct obj_data * obj, int pos)
 {
   int j;
   int invalid_class(struct char_data *ch, struct obj_data *obj);
+  char buf[MAX_STRING_LENGTH];
 
   assert(pos >= 0 && pos < NUM_WEARS);
 
   if (GET_EQ(ch, pos)) {
     sprintf(buf, "SYSERR: Char is already equipped: %s, %s", GET_NAME(ch),
-	    obj->short_description);
+      obj->short_description);
     log(buf);
     return;
   }
@@ -701,28 +702,29 @@ void equip_char(struct char_data * ch, struct obj_data * obj, int pos)
       (IS_OBJ_STAT(obj, ITEM_ANTI_GOOD) && IS_GOOD(ch)) ||
       (IS_OBJ_STAT(obj, ITEM_ANTI_NEUTRAL) && IS_NEUTRAL(ch)) )
   {
-      act("You are zapped by $p and instantly let go of it.", 
-		FALSE, ch, obj, 0, TO_CHAR);
-      act("$n is zapped by $p and instantly lets go of it.", 
-		FALSE, ch, obj, 0, TO_ROOM);
-      obj_to_char(obj, ch);	/* changed to drop in inventory instead of
-				 * ground */
+      act("You are zapped by $p and instantly let go of it.",
+    FALSE, ch, obj, 0, TO_CHAR);
+      act("$n is zapped by $p and instantly lets go of it.",
+    FALSE, ch, obj, 0, TO_ROOM);
+      obj_to_char(obj, ch);  /* changed to drop in inventory instead of
+         * ground */
       return;
   }
   if (invalid_class(ch, obj))
   {
       act("You cannot use $p.", FALSE, ch, obj, 0, TO_CHAR);
-      obj_to_char(obj, ch);	/* drop in inventory instead of ground */
+      obj_to_char(obj, ch);  /* drop in inventory instead of ground */
       return;
   }
 
   if (IS_OBJ_STAT(obj, ITEM_TAKE_NAME))
   {
-      int nr = GET_OBJ_RNUM(obj);
-      if (obj->short_description &&
-	  obj->short_description != obj_proto[nr].short_description)
-	FREE(obj->short_description);
-      obj->short_description = tprintf("%s's %s", GET_NAME(ch), obj->name);
+    int nr = GET_OBJ_RNUM(obj);
+    if (obj->short_description &&
+      obj->short_description != obj_proto[nr].short_description)
+      FREE(obj->short_description);
+    sprintf(buf, "%s's %s", GET_NAME(ch), obj->name);
+    obj->short_description = str_dup(buf);
   }
 
   GET_EQ(ch, pos) = obj;
@@ -734,14 +736,14 @@ void equip_char(struct char_data * ch, struct obj_data * obj, int pos)
 
   if (ch->in_room != NOWHERE) {
     if (GET_OBJ_TYPE(obj) == ITEM_LIGHT)
-      if (GET_OBJ_VAL(obj, 2) != 0)	/* if light is ON */
-	world[ch->in_room].light++;
+      if (GET_OBJ_VAL(obj, 2) != 0)  /* if light is ON */
+  world[ch->in_room].light++;
   }
 
   for (j = 0; j < MAX_OBJ_AFFECT; j++)
     affect_modify_ar(ch, obj->affected[j].location,
-		  obj->affected[j].modifier,
-		  obj->obj_flags.bitvector, TRUE);
+      obj->affected[j].modifier,
+      obj->obj_flags.bitvector, TRUE);
 
   affect_total(ch);
   check_for_bad_stats(ch);
@@ -763,9 +765,12 @@ struct obj_data *unequip_char(struct char_data * ch, int pos)
 
   if (IS_OBJ_STAT(obj, ITEM_TAKE_NAME))
   {
-	if (obj->short_description)
-	  FREE(obj->short_description);
-	obj->short_description = tprintf("%s %s", AN(obj->name), obj->name);
+    int nr = GET_OBJ_RNUM(obj);
+    if (obj->short_description &&
+      obj->short_description != obj_proto[nr].short_description)
+      FREE(obj->short_description);
+  sprintf(buf, "%s %s", AN(obj->name), obj->name);
+  obj->short_description = str_dup(buf);
   }
 
   if (GET_OBJ_TYPE(obj) == ITEM_ARMOR)
@@ -773,16 +778,16 @@ struct obj_data *unequip_char(struct char_data * ch, int pos)
 
   if (ch->in_room != NOWHERE) {
     if (GET_OBJ_TYPE(obj) == ITEM_LIGHT)
-      if (GET_OBJ_VAL(obj, 2) != 0)	/* if light is ON */
-	world[ch->in_room].light--;
+      if (GET_OBJ_VAL(obj, 2) != 0)  /* if light is ON */
+  world[ch->in_room].light--;
   }
 
   GET_EQ(ch, pos) = NULL;
 
   for (j = 0; j < MAX_OBJ_AFFECT; j++)
     affect_modify_ar(ch, obj->affected[j].location,
-		  obj->affected[j].modifier,
-		  obj->obj_flags.bitvector, FALSE);
+      obj->affected[j].modifier,
+      obj->obj_flags.bitvector, FALSE);
 
   affect_total(ch);
 
@@ -805,7 +810,7 @@ int get_number(char **name)
 
     for (i = 0; *(number + i); i++)
       if (!isdigit(*(number + i)))
-	return 0;
+  return 0;
 
     return (atoi(number));
   }
@@ -871,7 +876,7 @@ struct char_data *get_char_room(char *name, int room)
   for (i = world[room].people; i && (j <= number); i = i->next_in_room)
     if (isname_with_abbrevs(tmp, i->player.name))
       if (++j == number)
-	return i;
+  return i;
 
   return NULL;
 }
@@ -971,7 +976,7 @@ void obj_from_obj(struct obj_data * obj)
     {
       GET_OBJ_WEIGHT(temp) -= GET_OBJ_WEIGHT(obj);
       if (GET_OBJ_WEIGHT(temp)<1) /*sanity check Serapis 970616*/
-	GET_OBJ_WEIGHT(temp)=1;
+  GET_OBJ_WEIGHT(temp)=1;
     }
 
   /* Subtract weight from char that carries the object */
@@ -1047,25 +1052,25 @@ void update_char_objects(struct char_data * ch)
   if (GET_EQ(ch, WEAR_HOLD) != NULL)
     if (GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == ITEM_LIGHT)
       if (GET_OBJ_VAL(GET_EQ(ch, WEAR_HOLD), 2) > 0) {
-	i = --GET_OBJ_VAL(GET_EQ(ch, WEAR_HOLD), 2);
-	if (i == 1) {
-	  act("Your light begins to flicker and fade.", 
-		FALSE, ch, 0, 0, TO_CHAR);
-	  act("$n's light begins to flicker and fade.", 
-		FALSE, ch, 0, 0, TO_ROOM);
-	} else if (i == 0) {
-	  act("Your light sputters out and dies.", FALSE, ch, 0, 0, TO_CHAR);
-	  act("$n's light sputters out and dies.", FALSE, ch, 0, 0, TO_ROOM);
-	  world[ch->in_room].light--;
- 	  for (j = 0; j < MAX_OBJ_AFFECT; j++)
+  i = --GET_OBJ_VAL(GET_EQ(ch, WEAR_HOLD), 2);
+  if (i == 1) {
+    act("Your light begins to flicker and fade.",
+    FALSE, ch, 0, 0, TO_CHAR);
+    act("$n's light begins to flicker and fade.",
+    FALSE, ch, 0, 0, TO_ROOM);
+  } else if (i == 0) {
+    act("Your light sputters out and dies.", FALSE, ch, 0, 0, TO_CHAR);
+    act("$n's light sputters out and dies.", FALSE, ch, 0, 0, TO_ROOM);
+    world[ch->in_room].light--;
+     for (j = 0; j < MAX_OBJ_AFFECT; j++)
              if (GET_EQ(ch, WEAR_HOLD)->affected[j].location!=APPLY_NONE)
-		affec = TRUE;
-	  if (!affec)
-	  {
-	    send_to_char("It crumbles into dust.\r\n", ch);
-	    extract_obj(unequip_char(ch, WEAR_HOLD));
-	  }
-	}
+    affec = TRUE;
+    if (!affec)
+    {
+      send_to_char("It crumbles into dust.\r\n", ch);
+      extract_obj(unequip_char(ch, WEAR_HOLD));
+    }
+  }
       }
 
   for (i = 0; i < NUM_WEARS; i++)
@@ -1079,7 +1084,7 @@ void update_char_objects(struct char_data * ch)
 
 
 /* Extract a ch completely from the world, and leave his stuff behind */
-void 
+void
 extract_char_final(struct char_data * ch)
 {
   struct char_data *k, *temp;
@@ -1102,7 +1107,7 @@ extract_char_final(struct char_data * ch)
   if (!IS_NPC(ch) && !ch->desc) {
     for (t_desc = descriptor_list; t_desc; t_desc = t_desc->next)
       if (t_desc->original == ch)
-	do_return(t_desc->character, "", 0, 0);
+  do_return(t_desc->character, "", 0, 0);
   }
   if (ch->in_room == NOWHERE) {
     log("SYSERR: NOWHERE extracting char. (handler.c, extract_char)");
@@ -1119,7 +1124,7 @@ extract_char_final(struct char_data * ch)
     }
     if (ch->desc->snoop_by) {
       SEND_TO_Q("Your victim is no longer among us.\r\n",
-		ch->desc->snoop_by);
+    ch->desc->snoop_by);
       ch->desc->snoop_by->snooping = NULL;
       ch->desc->snoop_by = NULL;
     }
@@ -1157,9 +1162,9 @@ extract_char_final(struct char_data * ch)
     save_char(ch, GET_LOADROOM(ch));  /* will allow correct reloading of characters */
     Crash_delete_crashfile(ch);
   } else {
-    if (GET_MOB_RNUM(ch) > -1)		/* if mobile */
+    if (GET_MOB_RNUM(ch) > -1)    /* if mobile */
       mob_index[GET_MOB_RNUM(ch)].number--;
-    clearMemory(ch);		/* Only NPC's can have memory */
+    clearMemory(ch);    /* Only NPC's can have memory */
     free_char(ch);
     freed = 1;
   }
@@ -1261,7 +1266,7 @@ struct char_data *get_player_vis(struct char_data * ch, char *name, int inroom)
 
   for (i = character_list; i; i = i->next)
     if (!IS_NPC(i) && (!inroom || i->in_room == ch->in_room) &&
-	!str_cmp(i->player.name, name) && CAN_SEE(ch, i))
+  !str_cmp(i->player.name, name) && CAN_SEE(ch, i))
       return i;
 
   return NULL;
@@ -1288,8 +1293,8 @@ get_char_room_vis(struct char_data * ch, char *name)
   for (i = world[ch->in_room].people; i && j <= number; i = i->next_in_room)
     if (isname_with_abbrevs(tmp, i->player.name))
       if (CAN_SEE(ch, i))
-	if (++j == number)
-	  return i;
+  if (++j == number)
+    return i;
 
   return NULL;
 }
@@ -1313,7 +1318,7 @@ struct char_data *get_char_vis(struct char_data * ch, char *name)
   for (i = character_list; i && (j <= number); i = i->next)
     if (isname(tmp, i->player.name) && CAN_SEE(ch, i))
       if (++j == number)
-	return i;
+  return i;
 
   return NULL;
 }
@@ -1321,7 +1326,7 @@ struct char_data *get_char_vis(struct char_data * ch, char *name)
 
 
 struct obj_data *get_obj_in_list_vis(struct char_data * ch, char *name,
-				              struct obj_data * list)
+                      struct obj_data * list)
 {
   struct obj_data *i;
   int j = 0, number;
@@ -1335,8 +1340,8 @@ struct obj_data *get_obj_in_list_vis(struct char_data * ch, char *name,
   for (i = list; i && (j <= number); i = i->next_content)
     if (isname_with_abbrevs(tmp, i->name))
       if (CAN_SEE_OBJ(ch, i) || GET_OBJ_TYPE(i) == ITEM_LIGHT)
-	if (++j == number)
-	  return i;
+  if (++j == number)
+    return i;
 
   return NULL;
 }
@@ -1368,8 +1373,8 @@ struct obj_data *get_obj_vis(struct char_data * ch, char *name)
   for (i = object_list; i && (j <= number); i = i->next)
     if (isname_with_abbrevs(tmp, i->name))
       if (CAN_SEE_OBJ(ch, i))
-	if (++j == number)
-	  return i;
+  if (++j == number)
+    return i;
 
   return NULL;
 }
@@ -1377,13 +1382,13 @@ struct obj_data *get_obj_vis(struct char_data * ch, char *name)
 
 
 struct obj_data *get_object_in_equip_vis(struct char_data * ch,
-		           char *arg, struct obj_data * equipment[], int *j)
+               char *arg, struct obj_data * equipment[], int *j)
 {
   for ((*j) = 0; (*j) < NUM_WEARS; (*j)++)
     if (equipment[(*j)])
       if (CAN_SEE_OBJ(ch, equipment[(*j)]))
-	if (isname_with_abbrevs(arg, equipment[(*j)]->name))
-	  return (equipment[(*j)]);
+  if (isname_with_abbrevs(arg, equipment[(*j)]->name))
+    return (equipment[(*j)]);
 
   return NULL;
 }
@@ -1470,7 +1475,7 @@ struct obj_data *create_money(int amount)
       new_descr->description = str_dup(buf);
     } else if (amount < 100000) {
       sprintf(buf, "You guess there are, maybe, %d coins.",
-	      1000 * ((amount / 1000) + number(0, (amount / 1000))));
+        1000 * ((amount / 1000) + number(0, (amount / 1000))));
       new_descr->description = str_dup(buf);
     } else
       new_descr->description = str_dup("There are a LOT of coins.");
@@ -1482,7 +1487,7 @@ struct obj_data *create_money(int amount)
   GET_OBJ_TYPE(obj) = ITEM_MONEY;
   for(y = 0; y < TW_ARRAY_MAX; y++)
      obj->obj_flags.wear_flags[y] = 0;
-  SET_BIT_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_TAKE); 
+  SET_BIT_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_TAKE);
   GET_OBJ_VAL(obj, 0) = amount;
   GET_OBJ_COST(obj) = amount;
   obj->item_number = NOTHING;
@@ -1506,7 +1511,7 @@ struct obj_data *create_money(int amount)
 /* one_argument routine).                                                 */
 
 int generic_find(char *arg, int bitvector, struct char_data * ch,
-		     struct char_data ** tar_ch, struct obj_data ** tar_obj)
+         struct char_data ** tar_ch, struct obj_data ** tar_obj)
 {
   int i, found;
   char name[256];
@@ -1519,7 +1524,7 @@ int generic_find(char *arg, int bitvector, struct char_data * ch,
   *tar_ch = NULL;
   *tar_obj = NULL;
 
-  if (IS_SET(bitvector, FIND_CHAR_ROOM)) {	/* Find person in room */
+  if (IS_SET(bitvector, FIND_CHAR_ROOM)) {  /* Find person in room */
     if ((*tar_ch = get_char_room_vis(ch, name))) {
       return (FIND_CHAR_ROOM);
     }
@@ -1532,8 +1537,8 @@ int generic_find(char *arg, int bitvector, struct char_data * ch,
   if (IS_SET(bitvector, FIND_OBJ_EQUIP)) {
     for (found = FALSE, i = 0; i < NUM_WEARS && !found; i++)
       if (GET_EQ(ch, i) && isname_with_abbrevs(name, GET_EQ(ch, i)->name)== 1) {
-	*tar_obj = GET_EQ(ch, i);
-	found = TRUE;
+  *tar_obj = GET_EQ(ch, i);
+  found = TRUE;
       }
     if (found) {
       return (FIND_OBJ_EQUIP);
@@ -1570,15 +1575,15 @@ int find_all_dots(char *arg)
     return FIND_INDIV;
 }
 
-struct char_data *get_player_hidden(struct char_data * ch, 
-					char *name, int inroom)
+struct char_data *get_player_hidden(struct char_data * ch,
+          char *name, int inroom)
 {
   struct char_data *i;
 
   for (i = character_list; i; i = i->next)
     if (!IS_NPC(i) && (!inroom || i->in_room == ch->in_room) &&
-	!str_cmp(i->player.name, name) && 
-	(CAN_SEE(ch, i)||IS_AFFECTED(i, AFF_HIDE)))
+  !str_cmp(i->player.name, name) &&
+  (CAN_SEE(ch, i)||IS_AFFECTED(i, AFF_HIDE)))
       return i;
 
   return NULL;
@@ -1604,9 +1609,8 @@ struct char_data *get_char_room_hidden(struct char_data * ch, char *name)
   for (i = world[ch->in_room].people; i && j <= number; i = i->next_in_room)
     if (isname_with_abbrevs(tmp, i->player.name))
       if (CAN_SEE(ch, i)||IS_AFFECTED(i, AFF_HIDE))
-	if (++j == number)
-	  return i;
+  if (++j == number)
+    return i;
 
   return NULL;
 }
-

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -900,6 +900,9 @@ void command_interpreter(struct char_data *ch, char *argument)
    * Patch sent by Eric Green and Stefan Wasilewski.
    */
   if (!isalpha(*argument)) {
+    if (*argument == '\033[A')
+      send_to_char("awesome!\r\n", ch);
+
     arg[0] = argument[0];
     arg[1] = '\0';
     line = argument + 1;

--- a/src/magic.c
+++ b/src/magic.c
@@ -63,9 +63,9 @@ void add_follower(struct char_data * ch, struct char_data * leader);
 int dice(int number, int size);
 extern struct spell_info_type spell_info[];
 int num_followers(struct char_data *ch);
-void send_to_zone(char *messg, struct char_data *ch);      
+void send_to_zone(char *messg, struct char_data *ch);
 struct char_data *read_mobile(int, int);
-void raw_kill(struct char_data * ch, int attacktype);  
+void raw_kill(struct char_data * ch, int attacktype);
 bool ok_to_damage(struct char_data *ch, struct char_data *victim, int is_magic);
 
 /* internal functions */
@@ -400,7 +400,7 @@ const byte saving_throws[NUM_CLASSES][5][41] = {
 		35, 33, 31, 29, 27, 25, 23, 21, 19, 17,		/* 21 - 30 */
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0}			/* 31 - 40 */
   }
-  
+
 };
 
 
@@ -495,7 +495,7 @@ has_reagents(struct char_data *ch, int spellnum)
 
 /* =========================================================================
    NAME       : get_reagent_names()
-   DESCRIPTION: 
+   DESCRIPTION:
    RETURNS    : ALLOCATED string of reagent names or NULL
    WARNINGS   :
    HISTORY    : Created by dkarnes 970624
@@ -505,25 +505,28 @@ char *
 get_reagent_names(int spellnum)
 {
   char *return_string = NULL;
+	char buf[MAX_STRING_LENGTH];
   int i, j;
+
   for (i = 0; i < r_reagents; i++)
     if(reagents[i][r_spellnum] == spellnum)
       for(j = r_item0; j <=r_item2; j++)
-	if(reagents[i][j])
-	  {
-	    struct obj_data *obj = read_object(reagents[i][j], VIRTUAL);
-	    if (obj)
+	      if(reagents[i][j])
 	      {
-		char *tmp = NULL;
-		if (return_string)
-		  tmp = return_string;
-		return_string = tprintf("%s%s%s", tmp?tmp:"", tmp?", ":"",
-					(obj)->short_description);
-		if (tmp)
-		  FREE(tmp);
-		extract_obj(obj);
+	        struct obj_data *obj = read_object(reagents[i][j], VIRTUAL);
+	        if (obj)
+	        {
+		        char *tmp = NULL;
+		        if (return_string)
+		          tmp = return_string;
+		        sprintf(buf, "%s%s%s", tmp?tmp:"", tmp?", ":"",
+						 (obj)->short_description);
+		      /*  if (tmp)
+		          FREE(tmp); */
+		        extract_obj(obj);
+						return_string = str_dup(buf);
+	        }
 	      }
-	  }
   return(return_string);
 }
 
@@ -561,28 +564,28 @@ mag_materials(struct char_data *ch, int item0, int item1, int item2,
       }
    }
 
-   if ((item0 > 0) || (item1 > 0) || (item2 > 0)) 
+   if ((item0 > 0) || (item1 > 0) || (item2 > 0))
       return (FALSE);
 
-   if (extract) 
+   if (extract)
    {
-      if (item0 < 0) 
+      if (item0 < 0)
       {
 	 obj_from_char(obj0);
 	 extract_obj(obj0);
       }
-      if (item1 < 0) 
+      if (item1 < 0)
       {
 	 obj_from_char(obj1);
 	 extract_obj(obj1);
       }
-      if (item2 < 0) 
+      if (item2 < 0)
       {
 	 obj_from_char(obj2);
 	 extract_obj(obj2);
       }
    }
-   if (verbose) 
+   if (verbose)
    {
       send_to_char("A puff of smoke rises from your pack.\r\n", ch);
       act("A puff of smoke rises from $n's pack.",
@@ -761,10 +764,10 @@ mag_damage(int level, struct char_data * ch, struct char_data * victim,
    case SPELL_HARM:
       dam = dice(12, 8) + level*2;
       break;
-      
+
       /* Ninja, Mage */
    case SPELL_SOUL_LEECH:
-   case SPELL_ENERGY_DRAIN: 
+   case SPELL_ENERGY_DRAIN:
       if (GET_LEVEL(victim) <= 2)
 	 dam = 100;
       else
@@ -776,7 +779,7 @@ mag_damage(int level, struct char_data * ch, struct char_data * victim,
            {
              stc("Pulling the vampire dust from a pocket, you throw it into"
                  " the air...\r\n", ch);
-             act("$n throws some dust into the air...", 
+             act("$n throws some dust into the air...",
 		TRUE, ch, NULL, NULL, TO_ROOM);
 	     dam +=reag;
            }
@@ -790,7 +793,7 @@ mag_damage(int level, struct char_data * ch, struct char_data * victim,
    case SPELL_ACID_BLAST:
       dam = dice(4, 3) + level;
       break;
-    
+
       /* PSI spells */
    case SPELL_MINDPOKE:
       dam = dice(3, 3) + level;
@@ -806,7 +809,7 @@ mag_damage(int level, struct char_data * ch, struct char_data * victim,
 
    case SPELL_PSIBLAST:
       dam = dice(15, 13) + 3 * level;
-    
+
       if (!number(0,30) && !IS_NPC(ch))
       {
          stc("Suddenly, your psionic power recoils!\r\n", ch);
@@ -841,7 +844,7 @@ mag_damage(int level, struct char_data * ch, struct char_data * victim,
             if (GET_HIT(ch) > GET_MAX_HIT(ch))
               GET_HIT(ch) = GET_MAX_HIT(ch);
             break;
-	 default: 
+	 default:
 	    break;
 	 }
    }
@@ -876,7 +879,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
    for (i = 0; i < MAX_SPELL_AFFECTS; i++)
    {
       af[i].type = spellnum;
-      af[i].bitvector = 0; 
+      af[i].bitvector = 0;
       af[i].modifier = 0;
       af[i].location = APPLY_NONE;
    }
@@ -902,7 +905,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       af[0].location = APPLY_AC;
       af[0].modifier = -15;
       af[0].duration = 24;
-      af[0].bitvector = AFF_NOTHING;  
+      af[0].bitvector = AFF_NOTHING;
       accum_duration = FALSE;
       to_vict = "You feel someone protecting you.";
       to_self = "The magick protects $M.";
@@ -978,7 +981,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
          if(reag)
            {
              stc("You throw a raven's feather into the air...\r\n", ch);
-             act("$n throws a feather into the air...", 
+             act("$n throws a feather into the air...",
 		TRUE, ch, NULL, NULL, TO_ROOM);
            }
       }
@@ -1141,7 +1144,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
    case SPELL_PROT_FROM_EVIL:
       if (IS_EVIL(victim))
       {
-	stc("You cannot protect yourself from the Evil inside you!\r\n",ch);	
+	stc("You cannot protect yourself from the Evil inside you!\r\n",ch);
         sprintf(buf, "%s killed by Protection from Evil.", GET_NAME(ch));
         mudlog(buf, BRF, LVL_IMMORT, TRUE);
         raw_kill(ch, TYPE_BLAST);
@@ -1151,7 +1154,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
 	 af[0].duration = 24;
 	 af[0].bitvector = AFF_PROTECT_EVIL;
 	 accum_duration = FALSE;
-	 to_vict = "A stream of silver light surges from your fingertips, " 
+	 to_vict = "A stream of silver light surges from your fingertips, "
 	    "covering you!";
 	 to_room = "A stream of silver light surges from $n's fingertips, "
 	    "covering $m!";
@@ -1159,7 +1162,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       break;
 
    case SPELL_PROT_FROM_GOOD:
-      if (IS_GOOD(victim)) 
+      if (IS_GOOD(victim))
       {
         stc("The forces of Light destroy you for your betrayal!\r\n",ch);
         sprintf(buf, "%s killed by Protection from Good.", GET_NAME(ch));
@@ -1207,7 +1210,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
 	}
       else
 	stc("You attempt the spell without the components...\r\n", ch);
-   
+
       if (!IS_NPC(victim) && !IS_OUTLAW(ch))
       {
         stc("Your spell fails to affect them because you are not an Outlaw!\r\n", ch);
@@ -1287,7 +1290,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
          to_self = "Your magic makes $M light footed.";
       }
       break;
-  
+
    case SPELL_CHAMELEON:
       af[0].duration = GET_LEVEL(ch);
       af[0].bitvector = AFF_HIDE;
@@ -1325,16 +1328,16 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       to_vict = "A globe of protection appears around you!";
       accum_duration = TRUE;
       break;
-    
+
    case SPELL_PSYSHIELD:
       af[0].location = APPLY_AC;
       af[0].modifier = -15;
       af[0].duration = GET_LEVEL(ch)/2;
-      af[0].bitvector = AFF_NOTHING;  
+      af[0].bitvector = AFF_NOTHING;
       accum_duration = TRUE;
       to_vict = "You feel a shield of energy form around you.";
       break;
-  
+
    case SPELL_GREATPERCEPT:
       af[1].duration = level/2 + 4;
       af[1].bitvector = AFF_DETECT_INVIS;
@@ -1355,7 +1358,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       to_vict = "Your eyes glow briefly.";
       to_room = "$n's eyes glow briefly.";
       break;
- 
+
    case SPELL_INTELLECT:
       af[0].location = APPLY_INT;
       af[0].modifier = 1;
@@ -1364,7 +1367,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       accum_affect = TRUE;
       to_vict= "Your head clears and you realize some of the secrets of life!";
       break;
-  
+
    case SPELL_MIND_BAR:
       af[0].location = APPLY_INT;
       af[0].modifier = -18;
@@ -1375,7 +1378,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
       to_vict="Suddenly, your mind numbs and you feel somewhat impaired.";
       to_self="You place a mental bar across $S mind.";
       break;
-  
+
    }
 
    /*
@@ -1404,7 +1407,7 @@ mag_affects(int level, struct char_data * ch, struct char_data * victim,
 
    af->by_type = BY_SPELL;
    af->obj_num = 0;
-   
+
 
    for (i = 0; i < MAX_SPELL_AFFECTS; i++)
       if (af[i].bitvector || (af[i].location != APPLY_NONE))
@@ -1465,17 +1468,17 @@ void
 mag_groups(int level, struct char_data * ch, int spellnum, int savetype)
 {
    struct char_data *k;
-   struct follow_type *f;   
-      
-   if (!ch) 
+   struct follow_type *f;
+
+   if (!ch)
       return;
-      
+
    if (!IS_AFFECTED(ch, AFF_GROUP))
       return;
-     
+
    if (!(k = ch->master))
       k = ch;
-      
+
    /* do all followers of k who are not ch */
    for (f = k->followers; f; f = f->next)
    {
@@ -1491,11 +1494,11 @@ mag_groups(int level, struct char_data * ch, int spellnum, int savetype)
    /* do k */
    if ((k->in_room == ch->in_room) && IS_AFFECTED(k, AFF_GROUP))
       perform_mag_groups(level, ch, k, spellnum, savetype);
-   
+
    /* do yourself if you didn't already */
    if (k != ch)
      perform_mag_groups(level, ch, ch, spellnum, savetype);
-      
+
 }
 
 /*
@@ -1588,7 +1591,7 @@ mag_areas(int level, struct char_data * ch, int spellnum, int savetype)
     act(to_char, FALSE, ch, 0, 0, TO_CHAR);
   if (to_room != NULL)
     act(to_room, FALSE, ch, 0, 0, TO_ROOM);
-  
+
 
   for (tch = world[ch->in_room].people; tch; tch = next_tch)
     {
@@ -1612,7 +1615,7 @@ mag_areas(int level, struct char_data * ch, int spellnum, int savetype)
 	continue;
       if (are_grouped(ch, tch))
 	continue;
-      
+
       if (spellnum == SPELL_MASS_DOMINATE)
         spell_charm(GET_LEVEL(ch),ch, tch, NULL, NULL);
       else
@@ -1673,7 +1676,7 @@ mag_summons(int level, struct char_data * ch, struct obj_data * obj,
 		      int spellnum, int savetype)
 {
    void add_follower_quiet(struct char_data *ch, struct char_data *leader);
-  
+
    struct char_data *mob = NULL;
    struct obj_data *tobj, *next_obj;
    int pfail = 0;
@@ -1731,7 +1734,7 @@ mag_summons(int level, struct char_data * ch, struct obj_data * obj,
 	 strcpy(GET_NAME(mob), GET_NAME(ch));
 	 strcpy(mob->player.short_descr, GET_NAME(ch));
       }
-      else if (spellnum == SPELL_ANIMATE_DEAD) { 
+      else if (spellnum == SPELL_ANIMATE_DEAD) {
          stc("The corpse starts to twitch, then stands with a"
 	     " life of it's own!\r\n", ch);
       }
@@ -1765,14 +1768,14 @@ mag_points(int level, struct char_data * ch, struct char_data * victim,
       hit = dice(2, 8) + 1 + (level >> 2);
       send_to_char("You feel better.\r\n", victim);
       if (ch !=victim)
-	 act("$N's wounds glow and mend themselves.", 
+	 act("$N's wounds glow and mend themselves.",
 	     TRUE, ch, 0, victim, TO_NOTVICT);
       break;
    case SPELL_CURE_CRITIC:
       hit = dice(5, 8) + 3 + (level >> 2);
       send_to_char("You feel a lot better!\r\n", victim);
       if (ch !=victim)
-	 act("$N's wounds glow and mend themselves.", 
+	 act("$N's wounds glow and mend themselves.",
 	     TRUE, ch, 0, victim, TO_NOTVICT);
       break;
    case SPELL_HEAL:
@@ -1789,7 +1792,7 @@ mag_points(int level, struct char_data * ch, struct char_data * victim,
 	 hit = 100 + dice(3, 8);
 	 send_to_char("A warm feeling floods your body.\r\n", victim);
 	 if (ch !=victim)
-	    act("$N's wounds glow and mend themselves.", 
+	    act("$N's wounds glow and mend themselves.",
 		TRUE, ch, 0, victim, TO_NOTVICT);
       }
       if (affected_by_spell(victim, SKILL_CUTTHROAT))
@@ -1799,7 +1802,7 @@ mag_points(int level, struct char_data * ch, struct char_data * victim,
       hit = 200;
       send_to_char("A warm feeling floods your body.\r\n", victim);
       if (ch !=victim)
-	 act("$N's wounds glow and mend themselves.", 
+	 act("$N's wounds glow and mend themselves.",
 	     TRUE, ch, 0, victim, TO_NOTVICT);
       if (affected_by_spell(victim, SKILL_CUTTHROAT))
 	 affect_from_char(victim, SKILL_CUTTHROAT);
@@ -1876,7 +1879,7 @@ mag_unaffects(int level, struct char_data * ch, struct char_data * victim,
    affect_from_char(victim, spell);
    if (spell2)
       affect_from_char(victim, spell2);
-	
+
    if (to_vict != NULL)
       act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
    if (to_room != NULL)

--- a/src/new_cmds2.c
+++ b/src/new_cmds2.c
@@ -23,7 +23,7 @@
 
 #include "config.h"
 #include "sysdep.h"
- 
+
 #include "structs.h"
 #include "utils.h"
 #include "comm.h"
@@ -50,10 +50,10 @@ extern struct zone_data *zone_table;
 
 
 /* extern functions */
-struct char_data *HUNTING(struct char_data *ch);   
+struct char_data *HUNTING(struct char_data *ch);
 ACMD(do_tell);
 ACMD(do_flee);
-void raw_kill(struct char_data * ch, int attacktype); 
+void raw_kill(struct char_data * ch, int attacktype);
 void set_hunting(struct char_data *ch, struct char_data *victim);
 void send_to_zone(char *messg, struct char_data *ch);
 void improve_skill(struct char_data *ch, int skill_num);
@@ -83,7 +83,7 @@ ACMD(do_scrounge)
 
    percent = number(1, 101);
    prob = GET_SKILL(ch, SKILL_SCROUNGE);
-  
+
       switch(sector_type)
 	{
          case SECT_FOREST:
@@ -165,15 +165,15 @@ ACMD(do_first_aid)
     percent = number(1, 101+GET_LEVEL(vict));
     prob = GET_SKILL(ch, SKILL_FIRST_AID);
 
-    if (percent < prob || GET_LEVEL(ch)>LVL_IMMORT) 
+    if (percent < prob || GET_LEVEL(ch)>LVL_IMMORT)
       {
       GET_HIT(vict) = 1;
       update_pos(vict);
-      act("You apply some makeshift bandages to $N's wounds.", 
+      act("You apply some makeshift bandages to $N's wounds.",
 	FALSE, ch, 0, vict, TO_CHAR);
-      act("$n applies some bandaging to $N's wounds.", 
+      act("$n applies some bandaging to $N's wounds.",
 	FALSE, ch, 0, vict, TO_NOTVICT);
-      act("$n applies some bandaging to your wounds.", 
+      act("$n applies some bandaging to your wounds.",
 	TRUE, ch, 0, vict, TO_VICT);
       improve_skill(ch, SKILL_FIRST_AID);
       WAIT_STATE(vict, PULSE_VIOLENCE);
@@ -181,7 +181,7 @@ ACMD(do_first_aid)
     else
       {
       send_to_char("You fumble and ruin the bandages.\r\n",ch);
-      act("$n fumbles with some bandaging and drops it all over the place!", 
+      act("$n fumbles with some bandaging and drops it all over the place!",
 	TRUE, ch, 0, 0, TO_ROOM);
       }
     WAIT_STATE(ch, PULSE_VIOLENCE + 3);
@@ -224,7 +224,7 @@ ACMD(do_disarm)
    {
      stc("You can't disarm them if you aren't fighting them!\r\n", ch);
      return;
-   } 
+   }
 
    percent = number(1, 101+GET_LEVEL(vict));
    prob = subcmd?200:GET_SKILL(ch, SKILL_DISARM);
@@ -271,7 +271,7 @@ ACMD(do_mindlink)
     if (!IS_NPC(vict))
    {
       act("$N stares at you blankly.", FALSE, ch, 0, vict, TO_CHAR);
-      act("$n stares at $N for a while and then falls flat on $s face.", 
+      act("$n stares at $N for a while and then falls flat on $s face.",
 	  FALSE, ch, 0, vict, TO_ROOM);
       stc("You fail.\r\n", ch);
       return;
@@ -293,7 +293,7 @@ ACMD(do_mindlink)
     }
     percent = number(1, 101);
     prob = GET_SKILL(ch, SKILL_MINDLINK);
-  
+
     if ((IS_PSIONIC(vict) || IS_MYSTIC(vict)) && percent<prob)
     {
       x = number((20 + GET_LEVEL(ch)), 100);
@@ -306,7 +306,7 @@ ACMD(do_mindlink)
     }
     else
     {
-      act("$n stares at $N for a while and then falls flat on $s face.", 
+      act("$n stares at $N for a while and then falls flat on $s face.",
 	FALSE, ch, 0, vict, TO_ROOM);
       GET_HIT(ch) -= 100;
       improve_skill(ch, SKILL_MINDLINK);
@@ -342,7 +342,7 @@ SPECIAL(beholder)
      return FALSE;
   }
 
-  if (GET_POS(ch) != POS_FIGHTING) {  
+  if (GET_POS(ch) != POS_FIGHTING) {
 		/* If he ain't fighting, try to charm, sleep, or curse */
     for (vict = world[ch->in_room].people; vict; vict = vict->next_in_room)
        targets++;
@@ -355,11 +355,11 @@ SPECIAL(beholder)
       return FALSE;
 
     targets = 0;
-    for (vict = world[ch->in_room].people; vict; vict = vict->next_in_room) 
+    for (vict = world[ch->in_room].people; vict; vict = vict->next_in_room)
        if(++targets == victim)
          break;
 
-    if(vict == ch || IS_NPC(vict)) 
+    if(vict == ch || IS_NPC(vict))
        return FALSE;
 
     switch (number(0, 2)) {
@@ -401,10 +401,10 @@ SPECIAL(beholder)
 /*
  *  Recharger mob special procedure   Part of Dark Pawns (www.mystech.com 4000)
  *
- *  Based on original recharger code by 
+ *  Based on original recharger code by
  *        David A. Carver <DCARVER@cougar.colstate.cc.oh.us>
  *
- *  Rewritten for mobiles and "personality" by 
+ *  Rewritten for mobiles and "personality" by
  *        Frontline (rparet@rubens.artisan.calpoly.edu) on 6/6/97.
  *  The author maintains exclusive rights to this code.
  *  Use only with permission.
@@ -419,14 +419,14 @@ SPECIAL(recharger)
   int maxcharge = 0, mincharge = 0, price = 0;
 
   if (!(CMD_IS("list") || CMD_IS("help") || CMD_IS("recharge")))
-    return FALSE; 
-  
+    return FALSE;
+
   if (CMD_IS("list") || CMD_IS("help"))
   {
     act("$n sighs loudly.", FALSE, me, 0, 0, TO_ROOM);
-    act("$n says 'I recharge wands and staves, of course!'", 
+    act("$n says 'I recharge wands and staves, of course!'",
 	FALSE, me, 0, 0, TO_ROOM);
-    act("$n says 'My price is 100 coins per spell level per charge..'", 
+    act("$n says 'My price is 100 coins per spell level per charge..'",
 	FALSE, me, 0, 0, TO_ROOM);
     act("$n says 'So a wand casting heal at level 25 would cost 2500 "
 	"coins per charge.'", FALSE, me, 0, 0, TO_ROOM);
@@ -434,7 +434,7 @@ SPECIAL(recharger)
 	"after charging.",FALSE, me, 0, 0, TO_ROOM);
     act("$n says 'That means that an item could have 1 charge maximum, with"
 	" 2 charges remaining (after a recharge)'", FALSE, me, 0, 0, TO_ROOM);
-    act("$n says 'To recharge an item type: recharge <staff or wand>.'", 
+    act("$n says 'To recharge an item type: recharge <staff or wand>.'",
 	FALSE, me, 0, 0, TO_ROOM);
     act("$n stares expectantly at $N.", 1, me, 0, ch, TO_NOTVICT);
     act("$n stares expectantly at you.", FALSE, me, 0, ch, TO_VICT);
@@ -452,14 +452,14 @@ SPECIAL(recharger)
     }
     if (GET_OBJ_TYPE(obj) != ITEM_STAFF && GET_OBJ_TYPE(obj) != ITEM_WAND)
     {
-      act("$n tells you, 'Ummm... does that look like a wand or staff to you?'", 
+      act("$n tells you, 'Ummm... does that look like a wand or staff to you?'",
 		FALSE, me, 0, ch, TO_VICT);
       act("$n shakes his head in disgust.", FALSE, me, 0, 0, TO_ROOM);
       return TRUE;
     }
     price = MAX(100, GET_OBJ_VAL(obj, 0)*100);
     if (GET_GOLD(ch) < price) {
-      act("$n tells you, 'You don't have enough gold!'", 
+      act("$n tells you, 'You don't have enough gold!'",
 	FALSE, me, 0, ch, TO_VICT);
       return TRUE;
     }
@@ -471,9 +471,9 @@ SPECIAL(recharger)
      GET_OBJ_VAL(obj, 2)++;
      GET_OBJ_VAL(obj, 1)--;
      GET_GOLD(ch) -= price;
-     act("$n waves his hands around and chants strange things.", 
+     act("$n waves his hands around and chants strange things.",
 	FALSE, me, 0, 0, TO_ROOM);
-     sprintf(buf, "The item now has %d charges remaining.\r\n", 
+     sprintf(buf, "The item now has %d charges remaining.\r\n",
 		GET_OBJ_VAL(obj, 2));
      send_to_char(buf, ch);
      }
@@ -490,9 +490,9 @@ SPECIAL(recharger)
 /* Bare-bones detect skill      Part of Dark Pawns (www.mystech.com 4000)
  *
  * Allows players to detect "secret" doors
- * 
+ *
  * Frontline 6/7/97
- * 
+ *
  * Updated and modernized on 19990429 by rparet
  *
  */
@@ -500,32 +500,32 @@ SPECIAL(recharger)
 ACMD(do_detect)
 {
   int dir;
-  
-  if (!GET_SKILL(ch, SKILL_DETECT) && !(GET_RACE(ch) == RACE_ELF)) 
+
+  if (!GET_SKILL(ch, SKILL_DETECT) && !(GET_RACE(ch) == RACE_ELF))
   {
    send_to_char("Yeah, right.\r\n", ch);
    return;
-  } 
+  }
 
   if (IS_AFFECTED(ch, AFF_BLIND))
   {
    send_to_char("You're fucking blind, you can't find anything!!\r\n",ch);
    return;
   }
-  
+
   send_to_char("You carefully check the room...\r\n", ch);
 
-  if (GET_SKILL(ch, SKILL_DETECT) <= number(1, 101)) 
+  if (GET_SKILL(ch, SKILL_DETECT) <= number(1, 101))
   {
    send_to_char("You can't seem to find anything.\r\n", ch);
    WAIT_STATE(ch, PULSE_VIOLENCE + 1);
    return;
-  } 
+  }
 
-  for (dir = 0; dir < NUM_OF_DIRS; dir++) 
+  for (dir = 0; dir < NUM_OF_DIRS; dir++)
   {
-     if (EXIT(ch, dir) && EXIT(ch, dir)->keyword) 
-       if (strstr(EXIT(ch, dir)->keyword, "secret")) 
+     if (EXIT(ch, dir) && EXIT(ch, dir)->keyword)
+       if (strstr(EXIT(ch, dir)->keyword, "secret"))
        {
          if (dir == UP)
            sprintf(buf, "You notice something funny about the ceiling.\r\n");
@@ -539,10 +539,10 @@ ACMD(do_detect)
 	}
   }
 
-} 
+}
 
 
-/* 
+/*
  * Function: attacks a PC that tries to get an object from
  * the room it is in.
  *
@@ -556,16 +556,16 @@ SPECIAL(no_get)
   if (!AWAKE(mobile) || GET_HIT(mobile)<=0)
 	return(FALSE);
 
-  if(CMD_IS("get") || CMD_IS("palm") || CMD_IS("take")) 
+  if(CMD_IS("get") || CMD_IS("palm") || CMD_IS("take"))
   {
      argument = two_arguments(argument, buf1, buf2);
-     
+
      if (*buf1 && *buf2)
         return FALSE;
-     else 
+     else
      {
        act("$n strikes at $N's hand!", TRUE, mobile, 0, ch, TO_NOTVICT);
-       act("$n strikes at your hand!", FALSE, mobile, 0, ch, TO_VICT); 
+       act("$n strikes at your hand!", FALSE, mobile, 0, ch, TO_VICT);
        hit(me, ch, TYPE_UNDEFINED);
        return TRUE;
      }
@@ -581,11 +581,11 @@ SPECIAL(no_get)
    summon mobiles that have powers based upon the level of the caster.
    Important procedural note: if you call this function with the hunting
    integer set to TRUE, the mobile will be loaded in room 18201 and start
-   hunting the player ch.  -rparet 19981107 
+   hunting the player ch.  -rparet 19981107
 */
 
 struct char_data
-*create_mobile (struct char_data *ch, int mob_number, int level, int hunting) 
+*create_mobile (struct char_data *ch, int mob_number, int level, int hunting)
 {
   struct char_data *mob = read_mobile(mob_number, VIRTUAL);
 
@@ -603,8 +603,8 @@ struct char_data
   GET_MAX_HIT(mob) = level > 30 ? GET_MAX_HIT(mob) + (560*(level-30)):
                      GET_MAX_HIT(mob);
   GET_HIT(mob) = GET_MAX_HIT(mob);
-  IS_CARRYING_N(mob) = 0;   
-  IS_CARRYING_W(mob) = 0; 
+  IS_CARRYING_N(mob) = 0;
+  IS_CARRYING_W(mob) = 0;
 
   if (mob && !mini_mud && ch && hunting)
   {
@@ -636,9 +636,9 @@ SPECIAL(black_horn)
           act("You inhale and blow deeply on $P.",TRUE, ch, 0, obj, TO_CHAR);
           stc("A deep, foreboding tone resounds through the air.\r\n", ch);
           act("$n blows on $P.", TRUE, ch, 0, obj, TO_ROOM);
-          act("A deep, foreboding tone resounds through the air.", 
+          act("A deep, foreboding tone resounds through the air.",
 		FALSE, ch, 0, 0, TO_ROOM);
-   	  switch(number(0, 5)) 
+   	  switch(number(0, 5))
 	  {
     		case 0: create_mobile(ch, 14503, 25, TRUE); break;
     		case 1: create_mobile(ch, 14504, 25, TRUE); break;
@@ -650,7 +650,7 @@ SPECIAL(black_horn)
           return(TRUE);
         }
   }
-  return(FALSE);     
+  return(FALSE);
 }
 
 
@@ -658,7 +658,7 @@ SPECIAL(black_horn)
 SPECIAL(zen_master)
 {
  struct char_data *vict;
- 
+
  if (cmd || GET_POS(ch) != POS_FIGHTING || !AWAKE(ch) || GET_HIT(ch)<=0)
     return FALSE;
 
@@ -672,12 +672,12 @@ SPECIAL(zen_master)
  switch(number(0,20)) {
     case 0:
      act("$n touches $N on the arm.", 1, ch, 0, vict, TO_NOTVICT);
-     act("$n touches you lightly on the arm.", 1, ch, 0, vict, TO_VICT);   
+     act("$n touches you lightly on the arm.", 1, ch, 0, vict, TO_VICT);
      call_magic(ch, vict, 0, SPELL_WORD_OF_RECALL,GET_LEVEL(ch),CAST_SPELL);
      return TRUE;
     case 20:
      act("$n says, 'You have violence, but not thought.'",
-	 FALSE,ch,0,0,TO_ROOM);   
+	 FALSE,ch,0,0,TO_ROOM);
      call_magic(ch, vict, 0, SPELL_TELEPORT, GET_LEVEL(ch), CAST_SPELL);
      return TRUE;
     default:
@@ -730,7 +730,7 @@ ACMD(do_serpent_kick)
   if (GET_POS(vict) <= POS_SLEEPING)
     prob=110;
 
-  if (percent > prob) 
+  if (percent > prob)
     damage(ch, vict, 0, SKILL_SERPENT_KICK);
   else
     {
@@ -772,45 +772,41 @@ hunt_items(void)
     if (!i->connected && i->character)
     {
      int j = 0, k = 0;
-     for (j = 0; j < NUM_WEARS; j++) 
+     for (j = 0; j < NUM_WEARS; j++)
      {
        struct obj_data *obj = NULL, *hunting = NULL;
        bool found = FALSE;
 
        if ( (obj = GET_EQ(i->character, j)) )
-	 for (k = 0; k < NUM_HUNTEDS; k++)
-	   if (GET_OBJ_VNUM(obj)==hunteds[k][h_item])
-	     if(number(0,100)<hunteds[k][h_percent])
-	     {
-  		for (ch = character_list; !found && ch; ch = next_ch) 
-		{
-    		   next_ch = ch->next;
-    		   if ( (GET_MOB_VNUM(ch)!=hunteds[k][h_hunter] && 
-			 GET_MOB_VNUM(ch)!=hunteds[k][h_hunter2]&&
-			 GET_MOB_VNUM(ch)!=hunteds[k][h_hunter3]) ||
-			FIGHTING(ch) || !AWAKE(ch) ||
-		        IS_AFFECTED(ch, AFF_CHARM) || HUNTING(ch))
-      		      continue;
-		   else
-		   {
-			found = TRUE;
-			hunting = obj;
-			break;
-		   }
-		}
-		if (found && ch)
-		{
-		  char *msg = NULL;
-      		  msg = tprintf("%s I must have %s!", GET_NAME(ch),
- 			(hunting)->short_description);
-		  if (msg)
-		  {
-      		    do_tell(ch, msg, find_command("tell"), 0);
-		    FREE(msg);
-		  }
-	          set_hunting(ch, i->character);
-		}
-	     }
+	       for (k = 0; k < NUM_HUNTEDS; k++)
+	         if (GET_OBJ_VNUM(obj)==hunteds[k][h_item])
+	           if(number(0,100)<hunteds[k][h_percent])
+	           {
+  		         for (ch = character_list; !found && ch; ch = next_ch)
+		           {
+    		         next_ch = ch->next;
+    		         if ( (GET_MOB_VNUM(ch)!=hunteds[k][h_hunter] &&
+			            GET_MOB_VNUM(ch)!=hunteds[k][h_hunter2]&&
+			            GET_MOB_VNUM(ch)!=hunteds[k][h_hunter3]) ||
+			            FIGHTING(ch) || !AWAKE(ch) ||
+		              IS_AFFECTED(ch, AFF_CHARM) || HUNTING(ch))
+      		         continue;
+		             else
+		             {
+			             found = TRUE;
+			             hunting = obj;
+			             break;
+		             }
+		           }
+          		 if (found && ch)
+          		 {
+          		   char msg[MAX_STRING_LENGTH];
+                 sprintf(msg, "%s I must have %s!", GET_NAME(ch),
+           			   (hunting)->short_description);
+          		   do_tell(ch, msg, find_command("tell"), 0);
+                 set_hunting(ch, i->character);
+          		 }
+	           }
      }
    }
 }
@@ -827,7 +823,7 @@ ACMD(do_dig)
   char buf2[10], buf3[10], buf[80];
   int iroom = 0, rroom = 0, dir = 0;
 
-  two_arguments(argument, buf2, buf3); 
+  two_arguments(argument, buf2, buf3);
   /* buf2 is the direction, buf3 is the room */
 
   iroom = atoi(buf3);
@@ -835,14 +831,14 @@ ACMD(do_dig)
 
   if (!*buf2 || !*buf3)
   {
-    send_to_char("Format: dig <dir> <room number>\r\n", ch); 
-    return; 
+    send_to_char("Format: dig <dir> <room number>\r\n", ch);
+    return;
   }
-  if (rroom <= 0) 
+  if (rroom <= 0)
   {
     sprintf(buf, "There is no room with the number %d.\r\n", iroom);
     send_to_char(buf, ch);
-    return; 
+    return;
   }
 
   if ((GET_LEVEL(ch) < LVL_SET_BUILD) &&
@@ -857,7 +853,7 @@ ACMD(do_dig)
   }
 
   /* Main stuff */
-  switch (*buf2) 
+  switch (*buf2)
   {
    case 'n': case 'N': dir = NORTH; break;
    case 'e': case 'E': dir = EAST; break;
@@ -865,19 +861,19 @@ ACMD(do_dig)
    case 'w': case 'W': dir = WEST; break;
    case 'u': case 'U': dir = UP; break;
    case 'd': case 'D': dir = DOWN; break;
-   default: 
-         stc("Valid dirs are n,s,e,w,u and d.\r\n", ch); 
+   default:
+         stc("Valid dirs are n,s,e,w,u and d.\r\n", ch);
   }
 
-  CREATE(world[rroom].dir_option[rev_dir[dir]], struct room_direction_data,1); 
+  CREATE(world[rroom].dir_option[rev_dir[dir]], struct room_direction_data,1);
   world[rroom].dir_option[rev_dir[dir]]->general_description = NULL;
   world[rroom].dir_option[rev_dir[dir]]->keyword = NULL;
-  world[rroom].dir_option[rev_dir[dir]]->to_room = ch->in_room; 
+  world[rroom].dir_option[rev_dir[dir]]->to_room = ch->in_room;
 
-  CREATE(world[ch->in_room].dir_option[dir], struct room_direction_data,1); 
+  CREATE(world[ch->in_room].dir_option[dir], struct room_direction_data,1);
   world[ch->in_room].dir_option[dir]->general_description = NULL;
   world[ch->in_room].dir_option[dir]->keyword = NULL;
-  world[ch->in_room].dir_option[dir]->to_room = rroom; 
+  world[ch->in_room].dir_option[dir]->to_room = rroom;
 
   /* Only works if you have Oasis OLC */
   olc_add_to_save_list((iroom/100), OLC_SAVE_ROOM);
@@ -897,39 +893,39 @@ flow_room(struct char_data *ch)
   if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_NORTH))
   {
     dir = NORTH;
-    sprintf(direct, "the south"); 
+    sprintf(direct, "the south");
   }
   else if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_SOUTH))
   {
-    sprintf(direct, "the north"); 
+    sprintf(direct, "the north");
     dir = SOUTH;
   }
   else if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_EAST))
   {
-    sprintf(direct, "the west"); 
+    sprintf(direct, "the west");
     dir = EAST;
   }
   else if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_WEST))
   {
-    sprintf(direct, "the east"); 
+    sprintf(direct, "the east");
     dir = WEST;
   }
   else if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_UP))
   {
-    sprintf(direct, "below"); 
+    sprintf(direct, "below");
     dir = UP;
   }
   else if(ROOM_FLAGGED(ch->in_room, ROOM_FLOW_DOWN))
   {
-    sprintf(direct, "above"); 
+    sprintf(direct, "above");
     dir = DOWN;
   }
 
-  if(dir < 0 || !world[was_in].dir_option[dir] || 
-     (GET_LEVEL(ch) >= LVL_IMMORT && PRF_FLAGGED(ch, PRF_NOHASSLE)) || 
+  if(dir < 0 || !world[was_in].dir_option[dir] ||
+     (GET_LEVEL(ch) >= LVL_IMMORT && PRF_FLAGGED(ch, PRF_NOHASSLE)) ||
      IS_NPC(ch) || world[was_in].dir_option[dir]->to_room==NOWHERE)
     return;
-  
+
 
 
   /*
@@ -970,7 +966,7 @@ ACMD(do_turn)
     send_to_char("Huh?!?\r\n", ch);
     return;
   }
-  
+
   if (IS_EVIL(ch) || IS_NEUTRAL(ch))
     {
       stc("You are not holy enough to turn away the Undead!\r\n", ch);
@@ -992,12 +988,12 @@ ACMD(do_turn)
       GET_MANA(ch) = 0;
     return;
   }
-  
+
   GET_MANA(ch) = GET_MANA(ch) - need_mana;
 
   for (tch = world[ch->in_room].people; tch; tch = next_tch)
   {
-    next_tch = tch->next_in_room; 
+    next_tch = tch->next_in_room;
     diff = 0;
 
     if(GET_RACE(tch) == RACE_UNDEAD || GET_RACE(tch) == RACE_VAMPIRE)
@@ -1024,7 +1020,7 @@ ACMD(do_turn)
       act("You are suddenly terrified!", FALSE, tch, 0, 0, TO_CHAR);
       do_flee(tch, "", 0, 0);
       continue;
-     }  
+     }
 
   }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -115,7 +115,7 @@ int str_cmp(char *arg1, char *arg2)
       else
 	return (1);
     }
-  
+
   return (0);
 }
 
@@ -297,7 +297,7 @@ struct time_info_data real_time_passed(time_t t2, time_t t1)
 
   now.month = -1;
   now.year = -1;
-  now.moon = 0; 
+  now.moon = 0;
 
   return now;
 }
@@ -340,7 +340,7 @@ struct time_info_data age(struct char_data *ch)
 struct time_info_data playing_time(struct char_data *ch)
 {
   struct time_info_data pt;
-  
+
   time_t secs = (time(0) - ch->player.time.logon) + ch->player.time.played;
 
   pt.year = 0;
@@ -406,7 +406,7 @@ void stop_follower(struct char_data * ch)
           affect_from_char(ch, SKILL_SHADOW);
           REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_DODGE);
           shadowing = TRUE;
-        }    
+        }
 
   if (IS_AFFECTED(ch, AFF_CHARM)) {
     act("You realize that $N is a jerk!", FALSE, ch, 0, ch->master, TO_CHAR);
@@ -531,12 +531,12 @@ int get_filename(char *orig_name, char *filename, int mode)
   switch (mode) {
   case POOF_FILE:
     prefix = "plrpoof";
-    suffix = "poof"; 
+    suffix = "poof";
     break;
-    
+
   case ALIAS_FILE:
     prefix = "plralias";
-    suffix = "alias"; 
+    suffix = "alias";
     break;
   case CRASH_FILE:
     prefix = "plrobjs";
@@ -601,16 +601,16 @@ parse_race(char arg)
 {
 	switch(arg)
 	{
-		case 'h': return RACE_HUMAN; 
-		case 'e': return RACE_ELF; 
-		case 'd': return RACE_DWARF; 
-		case 'k': return RACE_KENDER; 
-		case 'r': return RACE_RAKSHASA; 
-		case 'm': return RACE_MINOTAUR; 
+		case 'h': return RACE_HUMAN;
+		case 'e': return RACE_ELF;
+		case 'd': return RACE_DWARF;
+		case 'k': return RACE_KENDER;
+		case 'r': return RACE_RAKSHASA;
+		case 'm': return RACE_MINOTAUR;
 		case 's': return RACE_SSAUR;
 		default: break;
 	}
-	return RACE_UNDEFINED; 
+	return RACE_UNDEFINED;
 }
 
 struct char_data *
@@ -634,7 +634,7 @@ get_mount(struct char_data *ch)
 struct char_data *
 get_rider_in_room(struct char_data *mount)
 {
-  if (mount && IS_NPC(mount) && IS_MOUNTED(mount) && 
+  if (mount && IS_NPC(mount) && IS_MOUNTED(mount) &&
 	mount->master->in_room == mount->in_room)
     return (mount->master);
   return ((struct char_data *)NULL);
@@ -669,13 +669,13 @@ are_grouped(struct char_data *ch1, struct char_data *ch2)
       if (f->follower == ch2)
          return(TRUE);
    return FALSE;
-} 
+}
 
 bool
 is_intelligent(struct char_data *ch)
 {
   int i;
-  for (i=0; i<NUM_INTEL_RACES; i++) 
+  for (i=0; i<NUM_INTEL_RACES; i++)
 	if (GET_RACE(ch)==intelligent_races[i])
 		return(TRUE);
   return(FALSE);
@@ -705,8 +705,8 @@ get_char_by_id(long id)
 }
 
 void
-set_hunting(struct char_data *ch, struct char_data *vict) 
-{ 
+set_hunting(struct char_data *ch, struct char_data *vict)
+{
   if (!ch || (HUNTING(ch)&&HUNTING(ch)==vict) )
     return;
 
@@ -743,142 +743,12 @@ num_followers(struct char_data *ch)
 {
   int tot_members = 0;
   struct follow_type *f;
-  
+
   if (ch->followers)
     for (f = ch->followers; f; f = f->next)
       tot_members++;
 
    return(tot_members);
-}
-
-static int parse_command (char *ptr, char **f)
-{
-   double nf;
-
-   nf = strtod (ptr, f);
-
-   if (*f == ptr)
-      nf = 0;
-
-   return ((int)nf);
-}
-
-
-static int 
-total_bytes (char *fmt, va_list argptr)
-{
-   int len;
-   int size, psize;
-   char *ptr;
-   char *f;
-   char format[4];
-   char buffer[128];
-   int i;
-   unsigned u;
-   double d;
-
-   len = strlen(fmt);
-   ptr = strchr (fmt, '%');
-
-   /* skip past any escaped % characters */
-   while (ptr && *ptr && (*(ptr + 1) == '%'))
-      ptr = strchr (ptr + 2, '%');
-
-   while (ptr)
-   {
-      size = 0;
-      psize = parse_command (++ptr, &f);
-      sprintf (format, "%%%c", *f);
-
-      switch (*f)
-      {
-      case 'd':
-      case 'i':
-         i = va_arg (argptr, int);
-         sprintf (buffer, format, i);
-         size = strlen (buffer);
-         break;
-      case '%':
-         ptr++;
-      case 'c':
-         (void)va_arg (argptr, int);    /* char types are promoted to int */
-         size = sizeof(char);
-         break;
-      case 'e':
-      case 'E':
-      case 'g':
-      case 'f':
-      case 'G':
-         d = va_arg (argptr, double);
-         sprintf (buffer, format, d);
-         size = strlen (buffer);
-         break;
-      case 'u':
-      case 'o':
-      case 'x':
-      case 'X':
-         u = va_arg (argptr, unsigned int);
-         sprintf (buffer, format, u);
-         size = strlen (buffer);
-         break;
-      case 'p':
-         i = (int) va_arg (argptr, void *);
-         sprintf (buffer, format, i);
-         size = strlen (buffer);
-         break;
-      case 's':
-         f = va_arg (argptr, char *);
-         size = f ? strlen (f) : 0;
-         break;
-      default:
-         fprintf (stderr, "total_bytes: invalid format modifier <%c>\n", *f);
-         len = -1;
-         break;
-      }
-
-      if (len == -1)
-         break;
-
-      if (psize)
-         len += psize;
-      else
-         len += size;
-
-      ptr = strchr (ptr, '%');
-
-      /* skip past any escaped % characters */
-      while (ptr && *ptr && (*(ptr + 1) == '%'))
-         ptr = strchr (ptr + 2, '%');
-   }
-
-   return (len);
-}
-
-/*
- * char_string = tprintf("%s blah %d\r\n", some_string, some_int;
- * char_string will be allocated and must be FREEd
- */
-char *tprintf (char *fmt, ...)
-{
-   int bytes;
-   va_list params;
-   char *buffer = NULL;
-
-   va_start (params, fmt);
-
-   bytes = total_bytes (fmt, params);
-   if (bytes > 0)
-   {
-      buffer = (char *) calloc (bytes + 1, sizeof(char));
-      buffer[0] = '\0';
-   }
-
-   if (buffer)
-      vsprintf(buffer, fmt, params);
-
-   va_end (params);
-
-   return buffer;
 }
 
 struct char_data *
@@ -909,12 +779,16 @@ is_playing(char *vict_name)
  * (Note that you may have _expected_ truncation because you only wanted
  * a few characters from the source string.)
  */
-size_t strlcpy(char *dest, const char *source, size_t totalsize)
+
+/*
+ size_t strlcpy(char *dest, const char *source, size_t totalsize)
 {
-  strncpy(dest, source, totalsize - 1);	/* strncpy: OK (we must assume 'totalsize' is correct) */
+  strncpy(dest, source, totalsize - 1);
   dest[totalsize - 1] = '\0';
   return strlen(source);
 }
+
+*/
 
 /* sprintnbit function ported from Circle 3.1 (called sprintbit in Circle3.1) */
 /*
@@ -953,7 +827,7 @@ void sprintbitarray(int bitvector[], char *names[], int maxar, char *result)
   int i;
   size_t len;
   char tmp[MAX_STRING_LENGTH/4];
-  
+
   *result = '\0';
   len = 0;
 
@@ -1006,8 +880,8 @@ circle_check(struct char_data *ch)
 
   if (!ch || ch->in_room == NOWHERE)
     return FALSE;
-  
-  for (i = world[ch->in_room].contents; i; i = i->next_content) 
+
+  for (i = world[ch->in_room].contents; i; i = i->next_content)
   {
      if(i && GET_OBJ_VNUM(i) == COC_VNUM) {
        GET_OBJ_TIMER(i)--;
@@ -1096,11 +970,11 @@ bool matches(const char *s, const char *regex)
   int result;
   regex_t r;
 
-  regcomp(&r, regex, REG_EXTENDED);  
+  regcomp(&r, regex, REG_EXTENDED);
 
   result = !regexec(&r, s, 0, NULL, 0);
 
   regfree(&r);
-  
+
   return result;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -60,7 +60,6 @@ struct time_info_data age(struct char_data *ch);
 struct time_info_data playing_time(struct char_data *ch);
 bool    is_veteran(struct char_data *ch);
 int	num_pc_in_room(struct room_data *room);
-char   *tprintf(char *fmt, ...);
 void    sprintbitarray(int bitvector[], char *names[], int maxar, char *result);
 void    core_dump_real(const char *, int);
 bool    check_dead(struct char_data *ch);
@@ -105,7 +104,7 @@ void	gain_condition(struct char_data *ch, int condition, int value);
 void	check_idling(struct char_data *ch);
 void	point_update(void);
 void	update_pos(struct char_data *victim);
-bool    are_grouped(struct char_data *ch1, struct char_data *ch2);   
+bool    are_grouped(struct char_data *ch1, struct char_data *ch2);
 
 
 /* various constants *****************************************************/
@@ -147,7 +146,7 @@ bool    are_grouped(struct char_data *ch1, struct char_data *ch2);
 /* Misc. defines (rparet) */
 
 #define IS_FLYING(ch)   (IS_AFFECTED((ch), AFF_FLY) || \
-                           PRF_FLAGGED((ch),PRF_NOHASSLE))                 
+                           PRF_FLAGGED((ch),PRF_NOHASSLE))
 #define CAN_SWIM(ch)    (IS_AFFECTED((ch), AFF_WATERWALK) || \
                          IS_AFFECTED((ch), AFF_FLY) || \
                          PRF_FLAGGED((ch), PRF_NOHASSLE) || \
@@ -162,7 +161,7 @@ bool    are_grouped(struct char_data *ch1, struct char_data *ch2);
 #define LOWER(c)   (((c)>='A'  && (c) <= 'Z') ? ((c)+('a'-'A')) : (c))
 #define UPPER(c)   (((c)>='a'  && (c) <= 'z') ? ((c)+('A'-'a')) : (c) )
 
-#define ISNEWL(ch) ((ch) == '\n' || (ch) == '\r') 
+#define ISNEWL(ch) ((ch) == '\n' || (ch) == '\r')
 #define IF_STR(st) ((st) ? (st) : "\0")
 #define CAP(st)  (*(st) = UPPER(*(st)), st)
 
@@ -628,4 +627,3 @@ bool    are_grouped(struct char_data *ch1, struct char_data *ch2);
 #endif
 
 #endif  /* _UTILS_H */
-


### PR DESCRIPTION
new-style uses / optimizations of va_list. Unclear what the original
value-add of tprintf was anyway, so removed for more simple approaches
where it was used.

Also included some whitespace / formating changes.